### PR TITLE
feat: Phase 1 - 실시간 시세 대시보드 (#2)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -33,7 +33,15 @@ NAVER_CLIENT_ID=
 NAVER_CLIENT_SECRET=
 NAVER_CALLBACK_URL=http://localhost/api/auth/naver/callback
 
-# Exchange Key Encryption
+# Exchange API Keys (Phase 3~4에서 필요, 시세 조회는 불필요)
+UPBIT_ACCESS_KEY=
+UPBIT_SECRET_KEY=
+BINANCE_API_KEY=
+BINANCE_SECRET_KEY=
+BYBIT_API_KEY=
+BYBIT_SECRET_KEY=
+
+# Exchange Key Encryption (사용자 키 DB 저장 시 암호화)
 ENCRYPTION_MASTER_KEY=dev-master-key-change-me-32bytes!
 
 # Telegram

--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,25 @@ NAVER_CLIENT_SECRET=
 NAVER_CALLBACK_URL=http://localhost/api/auth/naver/callback
 
 # ============================================
-# Exchange API Key Encryption
+# Exchange - Upbit (https://upbit.com > 마이페이지 > Open API 관리)
+# ============================================
+UPBIT_ACCESS_KEY=
+UPBIT_SECRET_KEY=
+
+# ============================================
+# Exchange - Binance (https://www.binance.com > 프로필 > API 관리)
+# ============================================
+BINANCE_API_KEY=
+BINANCE_SECRET_KEY=
+
+# ============================================
+# Exchange - Bybit (https://www.bybit.com > 계정 > API 관리)
+# ============================================
+BYBIT_API_KEY=
+BYBIT_SECRET_KEY=
+
+# ============================================
+# Exchange API Key Encryption (사용자 거래소 키 DB 저장 시 암호화용)
 # ============================================
 ENCRYPTION_MASTER_KEY=your-32-byte-hex-master-key-change-me
 

--- a/apps/api-server/Dockerfile
+++ b/apps/api-server/Dockerfile
@@ -25,27 +25,13 @@ WORKDIR /app/apps/api-server
 EXPOSE 3000
 CMD ["pnpm", "dev"]
 
-# Build
+# Build + deploy
 FROM base AS builder
 COPY --from=deps /app ./
 COPY . .
 RUN pnpm --filter @coin/types --filter @coin/utils --filter @coin/database --filter @coin/kafka-contracts --filter @coin/exchange-adapters build && \
-    pnpm --filter api-server build
-
-# Production dependencies only
-FROM base AS prod-deps
-COPY --from=deps /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/package.json ./
-COPY --from=deps /app/apps/api-server/package.json ./apps/api-server/
-COPY --from=deps /app/apps/web/package.json ./apps/web/
-COPY --from=deps /app/apps/worker-service/package.json ./apps/worker-service/
-COPY --from=deps /app/packages/types/package.json ./packages/types/
-COPY --from=deps /app/packages/database/package.json ./packages/database/
-COPY --from=deps /app/packages/kafka-contracts/package.json ./packages/kafka-contracts/
-COPY --from=deps /app/packages/utils/package.json ./packages/utils/
-COPY --from=deps /app/packages/exchange-adapters/package.json ./packages/exchange-adapters/
-COPY --from=deps /app/packages/tsconfig/package.json ./packages/tsconfig/
-COPY --from=deps /app/packages/eslint-config/package.json ./packages/eslint-config/
-RUN pnpm install --frozen-lockfile --prod
+    pnpm --filter api-server build && \
+    pnpm --filter api-server deploy --prod /app/deployed
 
 # Production
 FROM node:20-alpine AS production
@@ -53,13 +39,7 @@ ENV NODE_ENV=production
 WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nestjs
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=builder /app/apps/api-server/dist ./dist
-COPY --from=builder /app/packages/types/dist ./node_modules/@coin/types/dist
-COPY --from=builder /app/packages/utils/dist ./node_modules/@coin/utils/dist
-COPY --from=builder /app/packages/database/dist ./node_modules/@coin/database/dist
-COPY --from=builder /app/packages/kafka-contracts/dist ./node_modules/@coin/kafka-contracts/dist
-COPY --from=builder /app/packages/exchange-adapters/dist ./node_modules/@coin/exchange-adapters/dist
+COPY --from=builder /app/deployed ./
 USER nestjs
 EXPOSE 3000
 CMD ["node", "dist/main.js"]

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -21,6 +21,8 @@
     "@nestjs/microservices": "^11",
     "@nestjs/websockets": "^11",
     "@nestjs/platform-socket.io": "^11",
+    "ioredis": "^5",
+    "socket.io": "^4",
     "kafkajs": "^2",
     "reflect-metadata": "^0.2",
     "rxjs": "^7"

--- a/apps/api-server/src/app.module.ts
+++ b/apps/api-server/src/app.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
+import { MarketsModule } from './markets/markets.module';
 
 @Module({
+  imports: [MarketsModule],
   controllers: [AppController],
 })
 export class AppModule {}

--- a/apps/api-server/src/markets/markets.controller.ts
+++ b/apps/api-server/src/markets/markets.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { MarketsService } from './markets.service';
+
+@Controller('markets')
+export class MarketsController {
+  constructor(private readonly marketsService: MarketsService) {}
+
+  @Get('tickers')
+  async getAllTickers() {
+    return this.marketsService.getAllTickers();
+  }
+
+  @Get('ticker/:exchange/:symbol')
+  async getTicker(
+    @Param('exchange') exchange: string,
+    @Param('symbol') symbol: string,
+  ) {
+    const ticker = await this.marketsService.getLatestTicker(exchange, symbol);
+    if (!ticker) {
+      return { error: 'Ticker not found' };
+    }
+    return ticker;
+  }
+}

--- a/apps/api-server/src/markets/markets.gateway.ts
+++ b/apps/api-server/src/markets/markets.gateway.ts
@@ -1,0 +1,40 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayInit,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Logger } from '@nestjs/common';
+import { Server, Socket } from 'socket.io';
+import { MarketsService } from './markets.service';
+
+@WebSocketGateway({
+  path: '/ws',
+  cors: { origin: '*' },
+})
+export class MarketsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly logger = new Logger(MarketsGateway.name);
+
+  @WebSocketServer()
+  server!: Server;
+
+  constructor(private readonly marketsService: MarketsService) {}
+
+  afterInit() {
+    this.marketsService.onTicker((ticker) => {
+      this.server.emit('ticker', ticker);
+    });
+    this.logger.log('WebSocket Gateway initialized');
+  }
+
+  handleConnection(client: Socket) {
+    this.logger.debug(`Client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.debug(`Client disconnected: ${client.id}`);
+  }
+}

--- a/apps/api-server/src/markets/markets.module.ts
+++ b/apps/api-server/src/markets/markets.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MarketsGateway } from './markets.gateway';
+import { MarketsService } from './markets.service';
+import { MarketsController } from './markets.controller';
+
+@Module({
+  providers: [MarketsGateway, MarketsService],
+  controllers: [MarketsController],
+})
+export class MarketsModule {}

--- a/apps/api-server/src/markets/markets.service.ts
+++ b/apps/api-server/src/markets/markets.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
+import { Kafka, Consumer } from 'kafkajs';
+import Redis from 'ioredis';
+import { Ticker } from '@coin/types';
+import { KAFKA_TOPICS } from '@coin/kafka-contracts';
+
+@Injectable()
+export class MarketsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(MarketsService.name);
+  private kafka: Kafka;
+  private consumer: Consumer;
+  private redis: Redis;
+  private tickerListeners: ((ticker: Ticker) => void)[] = [];
+
+  constructor() {
+    this.kafka = new Kafka({
+      clientId: 'api-server',
+      brokers: (process.env.KAFKA_BROKERS || 'localhost:9092').split(','),
+    });
+    this.consumer = this.kafka.consumer({ groupId: 'api-server-group' });
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+  }
+
+  async onModuleInit() {
+    await this.consumer.connect();
+    await this.consumer.subscribe({
+      topic: KAFKA_TOPICS.MARKET_TICKER_UPDATED,
+      fromBeginning: false,
+    });
+
+    await this.consumer.run({
+      eachMessage: async ({ message }) => {
+        if (!message.value) return;
+        try {
+          const ticker: Ticker = JSON.parse(message.value.toString());
+          for (const listener of this.tickerListeners) {
+            listener(ticker);
+          }
+        } catch (err) {
+          this.logger.error(`Failed to parse ticker: ${err}`);
+        }
+      },
+    });
+
+    this.logger.log('Kafka consumer started - listening for ticker updates');
+  }
+
+  async onModuleDestroy() {
+    await this.consumer.disconnect();
+    this.redis.disconnect();
+  }
+
+  onTicker(callback: (ticker: Ticker) => void) {
+    this.tickerListeners.push(callback);
+  }
+
+  async getLatestTicker(exchange: string, symbol: string): Promise<Ticker | null> {
+    const key = `ticker:${exchange}:${symbol}`;
+    const data = await this.redis.get(key);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async getAllTickers(): Promise<Ticker[]> {
+    const keys = await this.redis.keys('ticker:*');
+    if (keys.length === 0) return [];
+    const values = await this.redis.mget(...keys);
+    return values
+      .filter((v): v is string => v !== null)
+      .map((v) => JSON.parse(v));
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "@coin/types": "workspace:*",
+    "lightweight-charts": "^4",
     "next": "^15",
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "socket.io-client": "^4"
   },
   "devDependencies": {
     "@coin/tsconfig": "workspace:*",

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useTickers } from '@/hooks/use-tickers';
+import { TickerTable } from '@/components/ticker-table';
+
+export default function MarketsPage() {
+  const { tickers, connected } = useTickers();
+
+  return (
+    <main style={{ maxWidth: '1200px', margin: '0 auto', padding: '24px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+        <h1 style={{ fontSize: '24px', fontWeight: 700 }}>Markets</h1>
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '6px',
+            fontSize: '13px',
+            color: connected ? '#22c55e' : '#ef4444',
+          }}
+        >
+          <span
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              backgroundColor: connected ? '#22c55e' : '#ef4444',
+            }}
+          />
+          {connected ? 'Connected' : 'Disconnected'}
+        </span>
+      </div>
+
+      <TickerTable tickers={tickers} />
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,8 +1,5 @@
+import { redirect } from 'next/navigation';
+
 export default function Home() {
-  return (
-    <main>
-      <h1>Coin Trading Platform</h1>
-      <p>Ready for development.</p>
-    </main>
-  );
+  redirect('/markets');
 }

--- a/apps/web/src/components/ticker-table.tsx
+++ b/apps/web/src/components/ticker-table.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Ticker } from '@coin/types';
+
+interface TickerTableProps {
+  tickers: Ticker[];
+}
+
+function formatPrice(price: string): string {
+  const num = Number(price);
+  if (num >= 1000) return num.toLocaleString('ko-KR', { maximumFractionDigits: 0 });
+  if (num >= 1) return num.toLocaleString('ko-KR', { maximumFractionDigits: 2 });
+  return num.toLocaleString('ko-KR', { maximumFractionDigits: 8 });
+}
+
+function formatVolume(volume: string): string {
+  const num = Number(volume);
+  if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(2)}M`;
+  if (num >= 1_000) return `${(num / 1_000).toFixed(2)}K`;
+  return num.toFixed(2);
+}
+
+export function TickerTable({ tickers }: TickerTableProps) {
+  const sorted = [...tickers].sort((a, b) => {
+    if (a.symbol < b.symbol) return -1;
+    if (a.symbol > b.symbol) return 1;
+    return a.exchange.localeCompare(b.exchange);
+  });
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'monospace', fontSize: '14px' }}>
+        <thead>
+          <tr style={{ borderBottom: '2px solid #333', textAlign: 'left' }}>
+            <th style={{ padding: '8px' }}>Exchange</th>
+            <th style={{ padding: '8px' }}>Symbol</th>
+            <th style={{ padding: '8px', textAlign: 'right' }}>Price</th>
+            <th style={{ padding: '8px', textAlign: 'right' }}>24h Change</th>
+            <th style={{ padding: '8px', textAlign: 'right' }}>24h High</th>
+            <th style={{ padding: '8px', textAlign: 'right' }}>24h Low</th>
+            <th style={{ padding: '8px', textAlign: 'right' }}>Volume</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.length === 0 ? (
+            <tr>
+              <td colSpan={7} style={{ padding: '24px', textAlign: 'center', color: '#888' }}>
+                Waiting for ticker data...
+              </td>
+            </tr>
+          ) : (
+            sorted.map((t) => {
+              const changeNum = Number(t.changePercent24h);
+              const changeColor = changeNum > 0 ? '#22c55e' : changeNum < 0 ? '#ef4444' : '#888';
+              return (
+                <tr key={`${t.exchange}:${t.symbol}`} style={{ borderBottom: '1px solid #222' }}>
+                  <td style={{ padding: '8px', textTransform: 'uppercase', fontWeight: 600 }}>
+                    {t.exchange}
+                  </td>
+                  <td style={{ padding: '8px' }}>{t.symbol}</td>
+                  <td style={{ padding: '8px', textAlign: 'right', fontWeight: 700 }}>
+                    {formatPrice(t.price)}
+                  </td>
+                  <td style={{ padding: '8px', textAlign: 'right', color: changeColor }}>
+                    {changeNum > 0 ? '+' : ''}{Number(t.changePercent24h).toFixed(2)}%
+                  </td>
+                  <td style={{ padding: '8px', textAlign: 'right' }}>{formatPrice(t.high24h)}</td>
+                  <td style={{ padding: '8px', textAlign: 'right' }}>{formatPrice(t.low24h)}</td>
+                  <td style={{ padding: '8px', textAlign: 'right' }}>{formatVolume(t.volume24h)}</td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-tickers.ts
+++ b/apps/web/src/hooks/use-tickers.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { Ticker } from '@coin/types';
+
+export function useTickers() {
+  const [tickers, setTickers] = useState<Map<string, Ticker>>(new Map());
+  const [connected, setConnected] = useState(false);
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    const socket = io({
+      path: '/ws',
+      transports: ['websocket'],
+    });
+
+    socketRef.current = socket;
+
+    socket.on('connect', () => setConnected(true));
+    socket.on('disconnect', () => setConnected(false));
+
+    socket.on('ticker', (ticker: Ticker) => {
+      setTickers((prev) => {
+        const next = new Map(prev);
+        next.set(`${ticker.exchange}:${ticker.symbol}`, ticker);
+        return next;
+      });
+    });
+
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  return { tickers: Array.from(tickers.values()), connected };
+}

--- a/apps/worker-service/Dockerfile
+++ b/apps/worker-service/Dockerfile
@@ -24,27 +24,13 @@ COPY . .
 WORKDIR /app/apps/worker-service
 CMD ["pnpm", "dev"]
 
-# Build
+# Build + deploy
 FROM base AS builder
 COPY --from=deps /app ./
 COPY . .
 RUN pnpm --filter @coin/types --filter @coin/utils --filter @coin/database --filter @coin/kafka-contracts --filter @coin/exchange-adapters build && \
-    pnpm --filter worker-service build
-
-# Production dependencies only
-FROM base AS prod-deps
-COPY --from=deps /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/package.json ./
-COPY --from=deps /app/apps/api-server/package.json ./apps/api-server/
-COPY --from=deps /app/apps/web/package.json ./apps/web/
-COPY --from=deps /app/apps/worker-service/package.json ./apps/worker-service/
-COPY --from=deps /app/packages/types/package.json ./packages/types/
-COPY --from=deps /app/packages/database/package.json ./packages/database/
-COPY --from=deps /app/packages/kafka-contracts/package.json ./packages/kafka-contracts/
-COPY --from=deps /app/packages/utils/package.json ./packages/utils/
-COPY --from=deps /app/packages/exchange-adapters/package.json ./packages/exchange-adapters/
-COPY --from=deps /app/packages/tsconfig/package.json ./packages/tsconfig/
-COPY --from=deps /app/packages/eslint-config/package.json ./packages/eslint-config/
-RUN pnpm install --frozen-lockfile --prod
+    pnpm --filter worker-service build && \
+    pnpm --filter worker-service deploy --prod /app/deployed
 
 # Production
 FROM node:20-alpine AS production
@@ -52,12 +38,6 @@ ENV NODE_ENV=production
 WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nestjs
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=builder /app/apps/worker-service/dist ./dist
-COPY --from=builder /app/packages/types/dist ./node_modules/@coin/types/dist
-COPY --from=builder /app/packages/utils/dist ./node_modules/@coin/utils/dist
-COPY --from=builder /app/packages/database/dist ./node_modules/@coin/database/dist
-COPY --from=builder /app/packages/kafka-contracts/dist ./node_modules/@coin/kafka-contracts/dist
-COPY --from=builder /app/packages/exchange-adapters/dist ./node_modules/@coin/exchange-adapters/dist
+COPY --from=builder /app/deployed ./
 USER nestjs
 CMD ["node", "dist/main.js"]

--- a/apps/worker-service/package.json
+++ b/apps/worker-service/package.json
@@ -19,6 +19,7 @@
     "@nestjs/common": "^11",
     "@nestjs/core": "^11",
     "@nestjs/microservices": "^11",
+    "ioredis": "^5",
     "kafkajs": "^2",
     "reflect-metadata": "^0.2",
     "rxjs": "^7"

--- a/apps/worker-service/src/app.module.ts
+++ b/apps/worker-service/src/app.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { ExchangesModule } from './exchanges/exchanges.module';
 
-@Module({})
+@Module({
+  imports: [ExchangesModule],
+})
 export class AppModule {}

--- a/apps/worker-service/src/exchanges/exchanges.module.ts
+++ b/apps/worker-service/src/exchanges/exchanges.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ExchangesService } from './exchanges.service';
+
+@Module({
+  providers: [ExchangesService],
+  exports: [ExchangesService],
+})
+export class ExchangesModule {}

--- a/apps/worker-service/src/exchanges/exchanges.service.ts
+++ b/apps/worker-service/src/exchanges/exchanges.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
+import { Kafka, Producer } from 'kafkajs';
+import Redis from 'ioredis';
+import { Ticker } from '@coin/types';
+import { KAFKA_TOPICS } from '@coin/kafka-contracts';
+import {
+  UpbitWebSocket,
+  BinanceWebSocket,
+  BybitWebSocket,
+  IExchangeWebSocket,
+} from '@coin/exchange-adapters';
+
+@Injectable()
+export class ExchangesService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ExchangesService.name);
+  private readonly adapters: IExchangeWebSocket[] = [];
+  private kafka: Kafka;
+  private producer: Producer;
+  private redis: Redis;
+
+  constructor() {
+    this.kafka = new Kafka({
+      clientId: 'worker-service',
+      brokers: (process.env.KAFKA_BROKERS || 'localhost:9092').split(','),
+    });
+    this.producer = this.kafka.producer();
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+  }
+
+  async onModuleInit() {
+    await this.producer.connect();
+    this.logger.log('Kafka producer connected');
+
+    const upbit = new UpbitWebSocket({
+      onConnected: () => this.logger.log('Upbit WebSocket connected'),
+      onDisconnected: () => this.logger.warn('Upbit WebSocket disconnected'),
+      onError: (err) => this.logger.error(`Upbit WS error: ${err.message}`),
+    });
+
+    const binance = new BinanceWebSocket({
+      onConnected: () => this.logger.log('Binance WebSocket connected'),
+      onDisconnected: () => this.logger.warn('Binance WebSocket disconnected'),
+      onError: (err) => this.logger.error(`Binance WS error: ${err.message}`),
+    });
+
+    const bybit = new BybitWebSocket({
+      onConnected: () => this.logger.log('Bybit WebSocket connected'),
+      onDisconnected: () => this.logger.warn('Bybit WebSocket disconnected'),
+      onError: (err) => this.logger.error(`Bybit WS error: ${err.message}`),
+    });
+
+    const tickerHandler = (ticker: Ticker) => this.handleTicker(ticker);
+
+    // Upbit: KRW-BTC 형식
+    upbit.subscribeTicker(['KRW-BTC', 'KRW-ETH', 'KRW-XRP'], tickerHandler);
+    upbit.connect();
+
+    // Binance: BTCUSDT 형식
+    binance.subscribeTicker(['BTCUSDT', 'ETHUSDT', 'XRPUSDT'], tickerHandler);
+
+    // Bybit: BTCUSDT 형식
+    bybit.subscribeTicker(['BTCUSDT', 'ETHUSDT', 'XRPUSDT'], tickerHandler);
+    bybit.connect();
+
+    this.adapters.push(upbit, binance, bybit);
+    this.logger.log('All exchange WebSocket adapters started');
+  }
+
+  async onModuleDestroy() {
+    for (const adapter of this.adapters) {
+      adapter.disconnect();
+    }
+    await this.producer.disconnect();
+    this.redis.disconnect();
+    this.logger.log('All connections closed');
+  }
+
+  private async handleTicker(ticker: Ticker) {
+    try {
+      // Redis cache
+      const key = `ticker:${ticker.exchange}:${ticker.symbol}`;
+      await this.redis.set(key, JSON.stringify(ticker), 'EX', 5);
+
+      // Kafka publish
+      await this.producer.send({
+        topic: KAFKA_TOPICS.MARKET_TICKER_UPDATED,
+        messages: [
+          {
+            key: `${ticker.exchange}:${ticker.symbol}`,
+            value: JSON.stringify(ticker),
+          },
+        ],
+      });
+    } catch (err) {
+      this.logger.error(`Failed to process ticker: ${err}`);
+    }
+  }
+}

--- a/apps/worker-service/src/main.ts
+++ b/apps/worker-service/src/main.ts
@@ -3,7 +3,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  console.log('worker-service started');
-  // Kafka microservice transport will be configured in Phase 1
+  await app.init();
+  console.log('worker-service started - exchange WebSocket connections active');
 }
 bootstrap();

--- a/packages/exchange-adapters/package.json
+++ b/packages/exchange-adapters/package.json
@@ -9,9 +9,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@coin/types": "workspace:*"
+    "@coin/types": "workspace:*",
+    "ws": "^8"
   },
   "devDependencies": {
+    "@types/ws": "^8",
     "typescript": "^5"
   }
 }

--- a/packages/exchange-adapters/src/binance/binance.ws.ts
+++ b/packages/exchange-adapters/src/binance/binance.ws.ts
@@ -1,0 +1,105 @@
+import WebSocket from 'ws';
+import { ExchangeId, Ticker } from '@coin/types';
+import { IExchangeWebSocket, WebSocketEventHandler } from '../interfaces/exchange-ws';
+
+export class BinanceWebSocket implements IExchangeWebSocket {
+  readonly exchangeId: ExchangeId = 'binance';
+  private ws: WebSocket | null = null;
+  private tickerCallback: ((ticker: Ticker) => void) | null = null;
+  private symbols: string[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private handlers: WebSocketEventHandler;
+
+  private static readonly WS_BASE = 'wss://stream.binance.com:9443/ws';
+
+  constructor(handlers: WebSocketEventHandler = {}) {
+    this.handlers = handlers;
+  }
+
+  connect(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) return;
+    if (this.symbols.length === 0) return;
+
+    // Binance: combined stream URL
+    const streams = this.symbols
+      .map((s) => `${s.toLowerCase()}@ticker`)
+      .join('/');
+    const url = `${BinanceWebSocket.WS_BASE}/${streams}`;
+
+    this.ws = new WebSocket(url);
+
+    this.ws.on('open', () => {
+      this.handlers.onConnected?.();
+    });
+
+    this.ws.on('message', (data: WebSocket.Data) => {
+      try {
+        const parsed = JSON.parse(data.toString());
+        if (parsed.e === '24hrTicker' && this.tickerCallback) {
+          this.tickerCallback(this.normalizeTicker(parsed));
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.handlers.onDisconnected?.();
+      this.scheduleReconnect();
+    });
+
+    this.ws.on('error', (err) => {
+      this.handlers.onError?.(err);
+    });
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  subscribeTicker(symbols: string[], callback: (ticker: Ticker) => void): void {
+    this.symbols = symbols;
+    this.tickerCallback = callback;
+    // Binance requires reconnect to change streams
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connect();
+  }
+
+  private normalizeTicker(raw: Record<string, unknown>): Ticker {
+    return {
+      exchange: 'binance',
+      symbol: raw.s as string,
+      price: raw.c as string,
+      volume24h: raw.v as string,
+      change24h: raw.p as string,
+      changePercent24h: raw.P as string,
+      high24h: raw.h as string,
+      low24h: raw.l as string,
+      timestamp: raw.E as number,
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 3000);
+  }
+}

--- a/packages/exchange-adapters/src/bybit/bybit.ws.ts
+++ b/packages/exchange-adapters/src/bybit/bybit.ws.ts
@@ -1,0 +1,127 @@
+import WebSocket from 'ws';
+import { ExchangeId, Ticker } from '@coin/types';
+import { IExchangeWebSocket, WebSocketEventHandler } from '../interfaces/exchange-ws';
+
+export class BybitWebSocket implements IExchangeWebSocket {
+  readonly exchangeId: ExchangeId = 'bybit';
+  private ws: WebSocket | null = null;
+  private tickerCallback: ((ticker: Ticker) => void) | null = null;
+  private symbols: string[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private handlers: WebSocketEventHandler;
+
+  private static readonly WS_URL = 'wss://stream.bybit.com/v5/public/spot';
+
+  constructor(handlers: WebSocketEventHandler = {}) {
+    this.handlers = handlers;
+  }
+
+  connect(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) return;
+
+    this.ws = new WebSocket(BybitWebSocket.WS_URL);
+
+    this.ws.on('open', () => {
+      this.handlers.onConnected?.();
+      this.startPing();
+      if (this.symbols.length > 0) {
+        this.sendSubscription();
+      }
+    });
+
+    this.ws.on('message', (data: WebSocket.Data) => {
+      try {
+        const parsed = JSON.parse(data.toString());
+        if (parsed.topic?.startsWith('tickers.') && parsed.data && this.tickerCallback) {
+          this.tickerCallback(this.normalizeTicker(parsed.data, parsed.topic));
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.handlers.onDisconnected?.();
+      this.stopPing();
+      this.scheduleReconnect();
+    });
+
+    this.ws.on('error', (err) => {
+      this.handlers.onError?.(err);
+    });
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.stopPing();
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  subscribeTicker(symbols: string[], callback: (ticker: Ticker) => void): void {
+    this.symbols = symbols;
+    this.tickerCallback = callback;
+    if (this.isConnected()) {
+      this.sendSubscription();
+    }
+  }
+
+  private sendSubscription(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    const args = this.symbols.map((s) => `tickers.${s}`);
+    this.ws.send(JSON.stringify({ op: 'subscribe', args }));
+  }
+
+  private normalizeTicker(raw: Record<string, unknown>, topic: string): Ticker {
+    const symbol = topic.replace('tickers.', '');
+    return {
+      exchange: 'bybit',
+      symbol,
+      price: raw.lastPrice as string,
+      volume24h: raw.volume24h as string,
+      change24h: String(
+        Number(raw.lastPrice) - Number(raw.prevPrice24h),
+      ),
+      changePercent24h: raw.price24hPcnt
+        ? String(Number(raw.price24hPcnt) * 100)
+        : '0',
+      high24h: raw.highPrice24h as string,
+      low24h: raw.lowPrice24h as string,
+      timestamp: Date.now(),
+    };
+  }
+
+  private startPing(): void {
+    this.pingTimer = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ op: 'ping' }));
+      }
+    }, 20000);
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 3000);
+  }
+}

--- a/packages/exchange-adapters/src/index.ts
+++ b/packages/exchange-adapters/src/index.ts
@@ -1,1 +1,4 @@
-export {};
+export { IExchangeWebSocket, WebSocketEventHandler } from './interfaces/exchange-ws';
+export { UpbitWebSocket } from './upbit/upbit.ws';
+export { BinanceWebSocket } from './binance/binance.ws';
+export { BybitWebSocket } from './bybit/bybit.ws';

--- a/packages/exchange-adapters/src/interfaces/exchange-ws.ts
+++ b/packages/exchange-adapters/src/interfaces/exchange-ws.ts
@@ -1,0 +1,15 @@
+import { ExchangeId, Ticker } from '@coin/types';
+
+export interface IExchangeWebSocket {
+  readonly exchangeId: ExchangeId;
+  connect(): void;
+  disconnect(): void;
+  isConnected(): boolean;
+  subscribeTicker(symbols: string[], callback: (ticker: Ticker) => void): void;
+}
+
+export type WebSocketEventHandler = {
+  onConnected?: () => void;
+  onDisconnected?: () => void;
+  onError?: (error: Error) => void;
+};

--- a/packages/exchange-adapters/src/upbit/upbit.ws.ts
+++ b/packages/exchange-adapters/src/upbit/upbit.ws.ts
@@ -1,0 +1,107 @@
+import WebSocket from 'ws';
+import { ExchangeId, Ticker } from '@coin/types';
+import { IExchangeWebSocket, WebSocketEventHandler } from '../interfaces/exchange-ws';
+
+export class UpbitWebSocket implements IExchangeWebSocket {
+  readonly exchangeId: ExchangeId = 'upbit';
+  private ws: WebSocket | null = null;
+  private tickerCallback: ((ticker: Ticker) => void) | null = null;
+  private symbols: string[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private handlers: WebSocketEventHandler;
+
+  private static readonly WS_URL = 'wss://api.upbit.com/websocket/v1';
+
+  constructor(handlers: WebSocketEventHandler = {}) {
+    this.handlers = handlers;
+  }
+
+  connect(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) return;
+
+    this.ws = new WebSocket(UpbitWebSocket.WS_URL);
+
+    this.ws.on('open', () => {
+      this.handlers.onConnected?.();
+      if (this.symbols.length > 0) {
+        this.sendSubscription();
+      }
+    });
+
+    this.ws.on('message', (data: WebSocket.Data) => {
+      try {
+        const parsed = JSON.parse(data.toString());
+        if (parsed.type === 'ticker' && this.tickerCallback) {
+          this.tickerCallback(this.normalizeTicker(parsed));
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.handlers.onDisconnected?.();
+      this.scheduleReconnect();
+    });
+
+    this.ws.on('error', (err) => {
+      this.handlers.onError?.(err);
+    });
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  subscribeTicker(symbols: string[], callback: (ticker: Ticker) => void): void {
+    this.symbols = symbols;
+    this.tickerCallback = callback;
+    if (this.isConnected()) {
+      this.sendSubscription();
+    }
+  }
+
+  private sendSubscription(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    // Upbit symbols: KRW-BTC 형식
+    const payload = JSON.stringify([
+      { ticket: `upbit-ticker-${Date.now()}` },
+      { type: 'ticker', codes: this.symbols },
+    ]);
+    this.ws.send(payload);
+  }
+
+  private normalizeTicker(raw: Record<string, unknown>): Ticker {
+    return {
+      exchange: 'upbit',
+      symbol: raw.code as string,
+      price: String(raw.trade_price),
+      volume24h: String(raw.acc_trade_volume_24h),
+      change24h: String(raw.signed_change_price),
+      changePercent24h: String(Number(raw.signed_change_rate) * 100),
+      high24h: String(raw.high_price),
+      low24h: String(raw.low_price),
+      timestamp: raw.timestamp as number,
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 3000);
+  }
+}

--- a/packages/kafka-contracts/src/index.ts
+++ b/packages/kafka-contracts/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './topics';

--- a/packages/kafka-contracts/src/topics.ts
+++ b/packages/kafka-contracts/src/topics.ts
@@ -1,0 +1,12 @@
+export const KAFKA_TOPICS = {
+  MARKET_TICKER_UPDATED: 'market.ticker.updated',
+  MARKET_ORDERBOOK_UPDATED: 'market.orderbook.updated',
+  TRADING_ORDER_REQUESTED: 'trading.order.requested',
+  TRADING_ORDER_RESULT: 'trading.order.result',
+  TRADING_STRATEGY_SIGNAL: 'trading.strategy.signal',
+  TRADING_POSITION_UPDATED: 'trading.position.updated',
+  NOTIFICATION_SEND: 'notification.send',
+  USER_EXCHANGE_KEYS_UPDATED: 'user.exchange-keys.updated',
+} as const;
+
+export type KafkaTopic = (typeof KAFKA_TOPICS)[keyof typeof KAFKA_TOPICS];

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,0 +1,13 @@
+import { Ticker, Orderbook } from './exchange';
+
+export interface TickerUpdatedEvent {
+  type: 'market.ticker.updated';
+  payload: Ticker;
+}
+
+export interface OrderbookUpdatedEvent {
+  type: 'market.orderbook.updated';
+  payload: Orderbook;
+}
+
+export type MarketEvent = TickerUpdatedEvent | OrderbookUpdatedEvent;

--- a/packages/types/src/exchange.ts
+++ b/packages/types/src/exchange.ts
@@ -1,1 +1,75 @@
 export type ExchangeId = 'upbit' | 'binance' | 'bybit';
+
+export interface ExchangeCredentials {
+  apiKey: string;
+  secretKey: string;
+}
+
+export interface Ticker {
+  exchange: ExchangeId;
+  symbol: string;
+  price: string;
+  volume24h: string;
+  change24h: string;
+  changePercent24h: string;
+  high24h: string;
+  low24h: string;
+  timestamp: number;
+}
+
+export interface OrderbookEntry {
+  price: string;
+  quantity: string;
+}
+
+export interface Orderbook {
+  exchange: ExchangeId;
+  symbol: string;
+  bids: OrderbookEntry[];
+  asks: OrderbookEntry[];
+  timestamp: number;
+}
+
+export interface Candle {
+  exchange: ExchangeId;
+  symbol: string;
+  interval: string;
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+  volume: string;
+  timestamp: number;
+}
+
+export interface Balance {
+  exchange: ExchangeId;
+  currency: string;
+  free: string;
+  locked: string;
+}
+
+export interface OrderRequest {
+  exchange: ExchangeId;
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'limit' | 'market';
+  quantity: string;
+  price?: string;
+}
+
+export interface OrderResult {
+  exchange: ExchangeId;
+  orderId: string;
+  symbol: string;
+  side: 'buy' | 'sell';
+  type: 'limit' | 'market';
+  status: 'pending' | 'placed' | 'filled' | 'partial' | 'cancelled' | 'failed';
+  quantity: string;
+  filledQuantity: string;
+  price: string;
+  filledPrice: string;
+  fee: string;
+  feeCurrency: string;
+  timestamp: number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './exchange';
+export * from './events';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.17)(@nestjs/platform-express@11.1.17)(@nestjs/websockets@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/microservices':
         specifier: ^11
-        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(ioredis@5.10.1)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
@@ -44,6 +44,9 @@ importers:
       '@nestjs/websockets':
         specifier: ^11
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/platform-socket.io@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      ioredis:
+        specifier: ^5
+        version: 5.10.1
       kafkajs:
         specifier: ^2
         version: 2.2.4
@@ -53,6 +56,9 @@ importers:
       rxjs:
         specifier: ^7
         version: 7.8.2
+      socket.io:
+        specifier: ^4
+        version: 4.8.3
     devDependencies:
       '@coin/tsconfig':
         specifier: workspace:*
@@ -72,6 +78,9 @@ importers:
       '@coin/types':
         specifier: workspace:*
         version: link:../../packages/types
+      lightweight-charts:
+        specifier: ^4
+        version: 4.2.3
       next:
         specifier: ^15
         version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -81,6 +90,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.4(react@19.2.4)
+      socket.io-client:
+        specifier: ^4
+        version: 4.8.3
     devDependencies:
       '@coin/tsconfig':
         specifier: workspace:*
@@ -123,7 +135,10 @@ importers:
         version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.17)(@nestjs/platform-express@11.1.17)(@nestjs/websockets@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/microservices':
         specifier: ^11
-        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(ioredis@5.10.1)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      ioredis:
+        specifier: ^5
+        version: 5.10.1
       kafkajs:
         specifier: ^2
         version: 2.2.4
@@ -186,7 +201,13 @@ importers:
       '@coin/types':
         specifier: workspace:*
         version: link:../types
+      ws:
+        specifier: ^8
+        version: 8.18.3
     devDependencies:
+      '@types/ws':
+        specifier: ^8
+        version: 8.18.1
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -599,6 +620,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1208,6 +1232,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1305,6 +1333,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1343,6 +1375,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
 
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
@@ -1478,6 +1513,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -1634,6 +1672,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -1723,6 +1765,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightweight-charts@4.2.3:
+    resolution: {integrity: sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1737,6 +1782,12 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2047,6 +2098,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -2143,6 +2202,10 @@ packages:
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
@@ -2165,6 +2228,9 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -2395,6 +2461,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -2776,6 +2846,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.15
 
+  '@ioredis/commands@1.5.1': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2847,11 +2919,11 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/microservices': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/microservices': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(ioredis@5.10.1)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
       '@nestjs/websockets': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/platform-socket.io@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
 
-  '@nestjs/microservices@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/microservices@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/websockets@11.1.17)(ioredis@5.10.1)(kafkajs@2.2.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.17)(@nestjs/platform-express@11.1.17)(@nestjs/websockets@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -2861,6 +2933,7 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/websockets': 11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)(@nestjs/platform-socket.io@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      ioredis: 5.10.1
       kafkajs: 2.2.4
 
   '@nestjs/platform-express@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)':
@@ -3417,6 +3490,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3494,6 +3569,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  denque@2.1.0: {}
+
   depd@2.0.0: {}
 
   destr@2.0.5: {}
@@ -3523,6 +3600,18 @@ snapshots:
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   engine.io-parser@5.2.3: {}
 
@@ -3700,6 +3789,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -3867,6 +3958,20 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
@@ -3934,6 +4039,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightweight-charts@4.2.3:
+    dependencies:
+      fancy-canvas: 2.1.0
+
   lines-and-columns@1.2.4: {}
 
   load-esm@1.0.3: {}
@@ -3943,6 +4052,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -4217,6 +4330,12 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect-metadata@0.2.2: {}
 
   require-from-string@2.0.2: {}
@@ -4373,6 +4492,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -4404,6 +4534,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 
@@ -4615,6 +4747,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- 3개 거래소(Upbit, Binance, Bybit) 실시간 WebSocket 시세 수집
- worker-service → Kafka → api-server → WebSocket Gateway → 브라우저 실시간 push
- Redis 캐시 + REST API (`/api/markets/tickers`)
- Next.js `/markets` 페이지: 실시간 시세 테이블

## Sourcery #9 피드백 반영
- [x] Dockerfile prod-deps에서 tsconfig/eslint-config 제거
- [x] `@coin/*/dist` 수동 복사 → `pnpm deploy --prod` 패턴 전환

## Architecture
```
[Upbit WS]   ──┐
[Binance WS] ──┤→ worker-service → Kafka → api-server → WS Gateway → Browser
[Bybit WS]   ──┘                        → Redis cache → REST API
```

## New Packages
- `packages/types`: Ticker, Orderbook, Candle, Order, Balance 타입 + Kafka event 타입
- `packages/kafka-contracts`: 토픽 상수
- `packages/exchange-adapters`: 3개 거래소 WebSocket 어댑터

## Verification
- `docker compose up -d` → 8개 컨테이너 기동 ✅
- 3개 거래소 WebSocket 연결 성공 (로그 확인) ✅
- `curl /api/markets/tickers` → BTC/ETH/XRP 실시간 데이터 반환 ✅
- `http://localhost/markets` → 시세 테이블 렌더링 ✅

## Test plan
- [x] `pnpm install && pnpm build` 전체 빌드 확인
- [ ] `cp .env.dev .env && docker compose up -d` 전체 기동
- [ ] `curl http://localhost/api/markets/tickers` 시세 데이터 확인
- [ ] 브라우저에서 `http://localhost/markets` 접속 → 실시간 시세 업데이트 확인

close #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement a real-time multi-exchange market data pipeline from worker-service through Kafka and Redis to the API server, and expose it to the web app via WebSocket and REST, with simplified Docker deployment flows.

New Features:
- Define shared exchange, ticker, orderbook, candle, balance, order, and market event types plus Kafka topic contracts for market and trading events.
- Add exchange WebSocket adapters for Upbit, Binance, and Bybit with a common interface for subscribing to ticker streams.
- Introduce a worker-service exchanges module that streams tickers from the three exchanges into Redis and Kafka.
- Add an API server markets module that consumes ticker updates from Kafka, serves them via REST endpoints, and broadcasts them over a WebSocket gateway.
- Create a Next.js /markets page with a live ticker table fed by a Socket.IO client hook, and redirect the root page to this dashboard.

Enhancements:
- Export exchange adapter and Kafka contracts modules from their package entrypoints to support reuse.
- Update worker-service bootstrap to fully initialize the Nest app before starting and log active WebSocket connections.

Build:
- Simplify api-server and worker-service Dockerfiles by replacing manual dist and dependency copying with a pnpm deploy --prod-based deployment image layout.