### PR TITLE
feat: zustand + react-query 데이터 페칭 아키텍처 마이그레이션

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^19",
     "socket.io-client": "^4",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@coin/tsconfig": "workspace:*",

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -11,6 +12,7 @@ import { login } from '@/lib/api-client';
 
 export default function LoginPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -22,6 +24,7 @@ export default function LoginPage() {
     setLoading(true);
     try {
       await login(email, password);
+      await queryClient.invalidateQueries({ queryKey: ['user'] });
       router.push('/markets');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');

--- a/apps/web/src/app/orders/page.tsx
+++ b/apps/web/src/app/orders/page.tsx
@@ -11,11 +11,11 @@ import {
   getOrders,
   createOrder,
   cancelOrder,
-  getMe,
   type ExchangeKeyItem,
 } from '@/lib/api-client';
 import { useTickers } from '@/hooks/use-tickers';
 import { useOrderUpdates } from '@/hooks/use-order-updates';
+import { useUser } from '@/hooks/use-user';
 import type { Ticker } from '@coin/types';
 
 const STATUS_STYLES: Record<string, string> = {
@@ -485,7 +485,7 @@ function OrdersTable() {
 
 export default function OrdersPage() {
   const queryClient = useQueryClient();
-  const [userId, setUserId] = useState<string | null>(null);
+  const { user } = useUser();
 
   const { data: keys = [] } = useQuery({
     queryKey: ['exchangeKeys'],
@@ -494,13 +494,7 @@ export default function OrdersPage() {
 
   const { tickers } = useTickers();
 
-  useEffect(() => {
-    getMe().then((user) => {
-      if (user) setUserId(user.id);
-    });
-  }, []);
-
-  useOrderUpdates(userId);
+  useOrderUpdates(user?.id ?? null);
 
   return (
     <div className="max-w-6xl mx-auto p-4 space-y-6">

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,7 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+function AuthRefreshListener({ queryClient }: { queryClient: QueryClient }) {
+  useEffect(() => {
+    const handler = () => {
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+    };
+    window.addEventListener('auth:refresh', handler);
+    return () => window.removeEventListener('auth:refresh', handler);
+  }, [queryClient]);
+  return null;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -16,5 +27,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
       }),
   );
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthRefreshListener queryClient={queryClient} />
+      {children}
+    </QueryClientProvider>
+  );
 }

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -11,6 +12,7 @@ import { signup } from '@/lib/api-client';
 
 export default function SignupPage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -30,6 +32,7 @@ export default function SignupPage() {
     setLoading(true);
     try {
       await signup(email, password, nickname || undefined);
+      await queryClient.invalidateQueries({ queryKey: ['user'] });
       router.push('/markets');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Signup failed');

--- a/apps/web/src/components/nav-bar.tsx
+++ b/apps/web/src/components/nav-bar.tsx
@@ -1,26 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { Button, buttonVariants } from '@/components/ui/button';
-import { getMe, logout } from '@/lib/api-client';
+import { useUser, useLogout } from '@/hooks/use-user';
 
 export function NavBar() {
-  const router = useRouter();
-  const [user, setUser] = useState<{ email: string; nickname?: string } | null>(null);
-
-  useEffect(() => {
-    getMe()
-      .then(setUser)
-      .catch(() => setUser(null));
-  }, []);
-
-  const handleLogout = async () => {
-    await logout();
-    setUser(null);
-    router.push('/login');
-  };
+  const { user } = useUser();
+  const logout = useLogout();
 
   return (
     <nav className="border-b">
@@ -56,7 +42,7 @@ export function NavBar() {
           {user ? (
             <>
               <span className="text-sm text-muted-foreground">{user.nickname || user.email}</span>
-              <Button variant="ghost" size="sm" onClick={handleLogout}>
+              <Button variant="ghost" size="sm" onClick={logout}>
                 Logout
               </Button>
             </>

--- a/apps/web/src/hooks/use-order-updates.ts
+++ b/apps/web/src/hooks/use-order-updates.ts
@@ -1,39 +1,17 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-
-interface OrderUpdate {
-  orderId: string;
-  status: string;
-  filledQuantity: string;
-  filledPrice: string;
-  fee: string;
-  feeCurrency: string;
-}
+import { useOrderUpdatesStore } from '@/stores/use-order-updates-store';
 
 export function useOrderUpdates(userId: string | null) {
-  const socketRef = useRef<Socket | null>(null);
   const queryClient = useQueryClient();
+  const connect = useOrderUpdatesStore((s) => s.connect);
+  const disconnect = useOrderUpdatesStore((s) => s.disconnect);
 
   useEffect(() => {
     if (!userId) return;
-
-    const socket = io({
-      path: '/ws',
-      transports: ['websocket'],
-      query: { userId },
-    });
-
-    socketRef.current = socket;
-
-    socket.on('order:updated', (_update: OrderUpdate) => {
-      queryClient.invalidateQueries({ queryKey: ['orders'] });
-    });
-
-    return () => {
-      socket.disconnect();
-    };
-  }, [userId, queryClient]);
+    connect(userId, queryClient);
+    return () => disconnect();
+  }, [userId, queryClient, connect, disconnect]);
 }

--- a/apps/web/src/hooks/use-tickers.ts
+++ b/apps/web/src/hooks/use-tickers.ts
@@ -1,37 +1,18 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
-import { Ticker } from '@coin/types';
+import { useEffect } from 'react';
+import { useTickersStore } from '@/stores/use-tickers-store';
 
 export function useTickers() {
-  const [tickers, setTickers] = useState<Map<string, Ticker>>(new Map());
-  const [connected, setConnected] = useState(false);
-  const socketRef = useRef<Socket | null>(null);
+  const connect = useTickersStore((s) => s.connect);
+  const disconnect = useTickersStore((s) => s.disconnect);
+  const connected = useTickersStore((s) => s.connected);
+  const getTickersArray = useTickersStore((s) => s.getTickersArray);
 
   useEffect(() => {
-    const socket = io({
-      path: '/ws',
-      transports: ['websocket'],
-    });
+    connect();
+    return () => disconnect();
+  }, [connect, disconnect]);
 
-    socketRef.current = socket;
-
-    socket.on('connect', () => setConnected(true));
-    socket.on('disconnect', () => setConnected(false));
-
-    socket.on('ticker', (ticker: Ticker) => {
-      setTickers((prev) => {
-        const next = new Map(prev);
-        next.set(`${ticker.exchange}:${ticker.symbol}`, ticker);
-        return next;
-      });
-    });
-
-    return () => {
-      socket.disconnect();
-    };
-  }, []);
-
-  return { tickers: Array.from(tickers.values()), connected };
+  return { tickers: getTickersArray(), connected };
 }

--- a/apps/web/src/hooks/use-user.ts
+++ b/apps/web/src/hooks/use-user.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { getMe, logout as apiLogout } from '@/lib/api-client';
+
+export function useUser() {
+  const { data: user = null, isLoading } = useQuery({
+    queryKey: ['user'],
+    queryFn: getMe,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+  return { user, isLoading };
+}
+
+export function useLogout() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return async () => {
+    await apiLogout();
+    queryClient.setQueryData(['user'], null);
+    queryClient.removeQueries({ queryKey: ['user'] });
+    router.push('/login');
+  };
+}

--- a/apps/web/src/stores/use-order-updates-store.ts
+++ b/apps/web/src/stores/use-order-updates-store.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import { io, Socket } from 'socket.io-client';
+import type { QueryClient } from '@tanstack/react-query';
+
+interface OrderUpdatesState {
+  _socket: Socket | null;
+  _userId: string | null;
+  connect: (userId: string, queryClient: QueryClient) => void;
+  disconnect: () => void;
+}
+
+export const useOrderUpdatesStore = create<OrderUpdatesState>((set, get) => ({
+  _socket: null,
+  _userId: null,
+
+  connect: (userId: string, queryClient: QueryClient) => {
+    const state = get();
+
+    // Already connected for this user
+    if (state._socket && state._userId === userId) return;
+
+    // Disconnect previous if user changed
+    if (state._socket) {
+      state._socket.disconnect();
+    }
+
+    const socket = io({
+      path: '/ws',
+      transports: ['websocket'],
+      query: { userId },
+    });
+
+    socket.on('order:updated', () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+    });
+
+    socket.on('strategy:signal', () => {
+      queryClient.invalidateQueries({ queryKey: ['strategies'] });
+    });
+
+    set({ _socket: socket, _userId: userId });
+  },
+
+  disconnect: () => {
+    const state = get();
+    if (state._socket) {
+      state._socket.disconnect();
+      set({ _socket: null, _userId: null });
+    }
+  },
+}));

--- a/apps/web/src/stores/use-tickers-store.ts
+++ b/apps/web/src/stores/use-tickers-store.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+import { io, Socket } from 'socket.io-client';
+import type { Ticker } from '@coin/types';
+
+interface TickersState {
+  tickers: Map<string, Ticker>;
+  connected: boolean;
+  _socket: Socket | null;
+  _refCount: number;
+  connect: () => void;
+  disconnect: () => void;
+  getTickersArray: () => Ticker[];
+}
+
+export const useTickersStore = create<TickersState>((set, get) => ({
+  tickers: new Map(),
+  connected: false,
+  _socket: null,
+  _refCount: 0,
+
+  connect: () => {
+    const state = get();
+    set({ _refCount: state._refCount + 1 });
+
+    if (state._socket) return;
+
+    const socket = io({
+      path: '/ws',
+      transports: ['websocket'],
+    });
+
+    socket.on('connect', () => set({ connected: true }));
+    socket.on('disconnect', () => set({ connected: false }));
+
+    socket.on('ticker', (ticker: Ticker) => {
+      set((prev) => {
+        const next = new Map(prev.tickers);
+        next.set(`${ticker.exchange}:${ticker.symbol}`, ticker);
+        return { tickers: next };
+      });
+    });
+
+    set({ _socket: socket });
+  },
+
+  disconnect: () => {
+    const state = get();
+    const nextRef = Math.max(0, state._refCount - 1);
+    set({ _refCount: nextRef });
+
+    if (nextRef === 0 && state._socket) {
+      state._socket.disconnect();
+      set({ _socket: null, connected: false });
+    }
+  },
+
+  getTickersArray: () => Array.from(get().tickers.values()),
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
       '@coin/tsconfig':
         specifier: workspace:*
@@ -5058,6 +5061,27 @@ packages:
       }
     engines: { node: '>=18' }
 
+  zustand@5.0.12:
+    resolution:
+      {
+        integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==,
+      }
+    engines: { node: '>=12.20.0' }
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7856,3 +7880,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4


### PR DESCRIPTION
## Summary
- zustand로 전역 클라이언트 상태 관리 (WebSocket 싱글턴 소켓)
- react-query로 서버 캐시 관리 (유저 프로필 `['user']` queryKey 공유)
- NavBar, Orders 페이지의 `useEffect+getMe()` → `useUser()` 훅으로 마이그레이션
- 티커 WebSocket 중복 연결 제거 (ref-counted 싱글턴 소켓)
- login/signup 후 `['user']` 캐시 무효화로 NavBar 자동 동기화
- `auth:refresh` 이벤트 리스너로 토큰 갱신 시 캐시 연동

## Test plan
- [x] Docker 빌드 성공, web 서비스 정상 기동
- [x] 모든 페이지 HTTP 200 반환 (markets, login)
- [x] API 엔드포인트 정상 동작 (strategies, orders, auth/me)
- [ ] 브라우저에서 NavBar 유저 표시 확인
- [ ] 페이지 이동 시 WebSocket 싱글턴 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate client data fetching and real-time updates to a shared react-query + zustand architecture.

New Features:
- Introduce a zustand store for shared ticker WebSocket state with reference-counted connections.
- Introduce a zustand store for order update WebSocket connections keyed by user and integrated with react-query cache invalidation.
- Add a reusable useUser hook and logout helper built on react-query user cache.

Bug Fixes:
- Prevent duplicate ticker WebSocket connections by centralizing connection management in a singleton store.
- Ensure order and strategy lists stay fresh by invalidating react-query caches on corresponding WebSocket events.
- Keep navigation user state consistent after auth refresh, login, and signup via centralized user query invalidation.

Enhancements:
- Refactor NavBar and Orders page to consume shared user state via the new useUser hook instead of local getMe calls.
- Wire a global auth:refresh listener into the app providers to automatically invalidate the user query on token refresh.
- Update login and signup flows to invalidate the shared user query so downstream components react to auth changes.

Build:
- Add zustand as a runtime dependency for global client state management.