### PR TITLE
feat: 알림 시스템 (Telegram + WebSocket toast) + 포트폴리오 대시보드

### DIFF
--- a/apps/api-server/Dockerfile
+++ b/apps/api-server/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 RUN pnpm install --frozen-lockfile
 WORKDIR /app/apps/api-server
 EXPOSE 3000
-CMD ["sh", "-c", "pnpm --filter @coin/database db:generate && pnpm --filter @coin/database build && pnpm --filter @coin/database exec prisma migrate deploy && pnpm dev"]
+CMD ["sh", "-c", "pnpm --filter @coin/database db:generate && pnpm --filter @coin/database build && pnpm --filter @coin/kafka-contracts build && pnpm --filter @coin/database exec prisma migrate deploy && pnpm dev"]
 
 # Build + deploy
 FROM base AS builder

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -39,7 +39,8 @@
     "passport-naver-v2": "^2.0.8",
     "reflect-metadata": "^0.2",
     "rxjs": "^7",
-    "socket.io": "^4"
+    "socket.io": "^4",
+    "telegraf": "^4.16.3"
   },
   "devDependencies": {
     "@coin/tsconfig": "workspace:*",

--- a/apps/api-server/src/app.module.ts
+++ b/apps/api-server/src/app.module.ts
@@ -8,6 +8,8 @@ import { AuthModule } from './auth/auth.module';
 import { ExchangeKeysModule } from './exchange-keys/exchange-keys.module';
 import { OrdersModule } from './orders/orders.module';
 import { StrategiesModule } from './strategies/strategies.module';
+import { NotificationsModule } from './notifications/notifications.module';
+import { PortfolioModule } from './portfolio/portfolio.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
 @Module({
@@ -19,6 +21,8 @@ import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
     ExchangeKeysModule,
     OrdersModule,
     StrategiesModule,
+    NotificationsModule,
+    PortfolioModule,
   ],
   controllers: [AppController],
   providers: [{ provide: APP_GUARD, useClass: JwtAuthGuard }],

--- a/apps/api-server/src/markets/markets.gateway.ts
+++ b/apps/api-server/src/markets/markets.gateway.ts
@@ -8,6 +8,7 @@ import {
 import { Logger } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { MarketsService } from './markets.service';
+import { NotificationsService } from '../notifications/notifications.service';
 
 @WebSocketGateway({
   path: '/ws',
@@ -27,7 +28,10 @@ export class MarketsGateway implements OnGatewayInit, OnGatewayConnection, OnGat
   @WebSocketServer()
   server!: Server;
 
-  constructor(private readonly marketsService: MarketsService) {}
+  constructor(
+    private readonly marketsService: MarketsService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
 
   afterInit() {
     this.marketsService.onTicker((ticker) => {
@@ -53,6 +57,14 @@ export class MarketsGateway implements OnGatewayInit, OnGatewayConnection, OnGat
         signal: payload.signal,
         strategyType: payload.strategyType,
         reason: payload.reason,
+      });
+    });
+
+    this.notificationsService.onNotification((payload) => {
+      this.server.to(`user:${payload.userId}`).emit('notification:received', {
+        type: payload.type,
+        title: payload.title,
+        message: payload.message,
       });
     });
 

--- a/apps/api-server/src/markets/markets.module.ts
+++ b/apps/api-server/src/markets/markets.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { MarketsGateway } from './markets.gateway';
 import { MarketsService } from './markets.service';
 import { MarketsController } from './markets.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
+  imports: [NotificationsModule],
   providers: [MarketsGateway, MarketsService],
   controllers: [MarketsController],
+  exports: [MarketsService],
 })
 export class MarketsModule {}

--- a/apps/api-server/src/markets/markets.service.ts
+++ b/apps/api-server/src/markets/markets.service.ts
@@ -1,9 +1,13 @@
 import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
-import { Kafka, Consumer } from 'kafkajs';
+import { Kafka, Consumer, Producer } from 'kafkajs';
 import Redis from 'ioredis';
 import { Ticker } from '@coin/types';
 import { KAFKA_TOPICS } from '@coin/kafka-contracts';
-import type { OrderResultEvent, StrategySignalEvent } from '@coin/kafka-contracts';
+import type {
+  OrderResultEvent,
+  StrategySignalEvent,
+  NotificationEvent,
+} from '@coin/kafka-contracts';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface StrategySignalPayload {
@@ -33,6 +37,7 @@ export class MarketsService implements OnModuleInit, OnModuleDestroy {
   private tickerConsumer: Consumer;
   private orderConsumer: Consumer;
   private strategyConsumer: Consumer;
+  private producer: Producer;
   private redis: Redis;
   private tickerListeners: ((ticker: Ticker) => void)[] = [];
   private orderListeners: ((payload: OrderUpdatePayload) => void)[] = [];
@@ -46,6 +51,7 @@ export class MarketsService implements OnModuleInit, OnModuleDestroy {
     this.tickerConsumer = this.kafka.consumer({ groupId: 'api-server-ticker' });
     this.orderConsumer = this.kafka.consumer({ groupId: 'api-server-orders' });
     this.strategyConsumer = this.kafka.consumer({ groupId: 'api-server-strategies' });
+    this.producer = this.kafka.producer();
     this.redis = new Redis({
       host: process.env.REDIS_HOST || 'localhost',
       port: Number(process.env.REDIS_PORT || 6379),
@@ -53,6 +59,8 @@ export class MarketsService implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleInit() {
+    await this.producer.connect();
+
     // Ticker consumer
     await this.tickerConsumer.connect();
     await this.tickerConsumer.subscribe({
@@ -130,6 +138,7 @@ export class MarketsService implements OnModuleInit, OnModuleDestroy {
     await this.tickerConsumer.disconnect();
     await this.orderConsumer.disconnect();
     await this.strategyConsumer.disconnect();
+    await this.producer.disconnect();
     this.redis.disconnect();
   }
 
@@ -174,6 +183,26 @@ export class MarketsService implements OnModuleInit, OnModuleDestroy {
 
     for (const listener of this.orderListeners) {
       listener(payload);
+    }
+
+    // Emit notification
+    const isFilled = result.status === 'filled' || result.status === 'partial';
+    const isFailed = result.status === 'failed';
+    if (isFilled || isFailed) {
+      const notif: NotificationEvent = {
+        userId,
+        type: isFilled ? 'order_filled' : 'order_failed',
+        title: isFilled
+          ? `주문 체결 | ${result.exchange.toUpperCase()} ${result.symbol}`
+          : `주문 실패 | ${result.exchange.toUpperCase()} ${result.symbol}`,
+        message: isFilled
+          ? `${result.side.toUpperCase()} ${result.filledQuantity} @ ${result.filledPrice}`
+          : `${result.side.toUpperCase()} ${result.quantity} — 체결 실패`,
+      };
+      await this.producer.send({
+        topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+        messages: [{ key: userId, value: JSON.stringify(notif) }],
+      });
     }
   }
 

--- a/apps/api-server/src/notifications/dto/update-notification-setting.dto.ts
+++ b/apps/api-server/src/notifications/dto/update-notification-setting.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsOptional, IsBoolean } from 'class-validator';
+
+export class UpdateNotificationSettingDto {
+  @IsOptional()
+  @IsString()
+  telegramChatId?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  notifyOrders?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  notifySignals?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  notifyRisks?: boolean;
+}

--- a/apps/api-server/src/notifications/notifications.controller.ts
+++ b/apps/api-server/src/notifications/notifications.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Patch, Body } from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateNotificationSettingDto } from './dto/update-notification-setting.dto';
+import type { User } from '@coin/database';
+
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Get('settings')
+  async getSettings(@CurrentUser() user: User) {
+    const setting = await this.prisma.notificationSetting.findUnique({
+      where: { userId: user.id },
+    });
+    return (
+      setting || {
+        telegramChatId: null,
+        notifyOrders: true,
+        notifySignals: true,
+        notifyRisks: false,
+      }
+    );
+  }
+
+  @Patch('settings')
+  async updateSettings(@CurrentUser() user: User, @Body() dto: UpdateNotificationSettingDto) {
+    return this.prisma.notificationSetting.upsert({
+      where: { userId: user.id },
+      create: {
+        userId: user.id,
+        ...dto,
+      },
+      update: dto,
+    });
+  }
+}

--- a/apps/api-server/src/notifications/notifications.module.ts
+++ b/apps/api-server/src/notifications/notifications.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { TelegramService } from './telegram.service';
+
+@Module({
+  controllers: [NotificationsController],
+  providers: [NotificationsService, TelegramService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/apps/api-server/src/notifications/notifications.service.ts
+++ b/apps/api-server/src/notifications/notifications.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
+import { Kafka, Consumer } from 'kafkajs';
+import { KAFKA_TOPICS } from '@coin/kafka-contracts';
+import type { NotificationEvent } from '@coin/kafka-contracts';
+import { PrismaService } from '../prisma/prisma.service';
+import { TelegramService } from './telegram.service';
+
+export interface NotificationPayload {
+  userId: string;
+  type: string;
+  title: string;
+  message: string;
+}
+
+@Injectable()
+export class NotificationsService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(NotificationsService.name);
+  private kafka: Kafka;
+  private consumer: Consumer;
+  private notificationListeners: ((payload: NotificationPayload) => void)[] = [];
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly telegram: TelegramService,
+  ) {
+    this.kafka = new Kafka({
+      clientId: 'api-notifications',
+      brokers: (process.env.KAFKA_BROKERS || 'localhost:9092').split(','),
+    });
+    this.consumer = this.kafka.consumer({
+      groupId: 'api-server-notifications',
+    });
+  }
+
+  async onModuleInit() {
+    await this.consumer.connect();
+    await this.consumer.subscribe({
+      topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+      fromBeginning: false,
+    });
+
+    await this.consumer.run({
+      eachMessage: async ({ message }) => {
+        if (!message.value) return;
+        try {
+          const event: NotificationEvent = JSON.parse(message.value.toString());
+          await this.handleNotification(event);
+        } catch (err) {
+          this.logger.error(`Failed to process notification: ${err}`);
+        }
+      },
+    });
+
+    this.logger.log('Notification consumer started');
+  }
+
+  async onModuleDestroy() {
+    await this.consumer.disconnect();
+  }
+
+  onNotification(callback: (payload: NotificationPayload) => void) {
+    this.notificationListeners.push(callback);
+  }
+
+  private async handleNotification(event: NotificationEvent) {
+    const { userId, type, title, message } = event;
+
+    // Check user notification preferences
+    const setting = await this.prisma.notificationSetting.findUnique({
+      where: { userId },
+    });
+
+    const shouldNotify =
+      !setting ||
+      (type === 'order_filled' && setting.notifyOrders) ||
+      (type === 'order_failed' && setting.notifyOrders) ||
+      (type === 'strategy_signal' && setting.notifySignals) ||
+      (type === 'risk_blocked' && setting.notifyRisks);
+
+    if (!shouldNotify) return;
+
+    // Telegram
+    if (setting?.telegramChatId) {
+      await this.telegram.sendNotification(setting.telegramChatId, title, message);
+    }
+
+    // WebSocket broadcast via listeners
+    const payload: NotificationPayload = { userId, type, title, message };
+    for (const listener of this.notificationListeners) {
+      listener(payload);
+    }
+
+    this.logger.log(`Notification sent to ${userId}: ${type}`);
+  }
+}

--- a/apps/api-server/src/notifications/telegram.service.ts
+++ b/apps/api-server/src/notifications/telegram.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
+import { Telegraf } from 'telegraf';
+
+@Injectable()
+export class TelegramService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(TelegramService.name);
+  private bot: Telegraf | null = null;
+
+  async onModuleInit() {
+    const token = process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) {
+      this.logger.warn('TELEGRAM_BOT_TOKEN not set — Telegram notifications disabled');
+      return;
+    }
+
+    this.bot = new Telegraf(token);
+
+    this.bot.start((ctx) => {
+      const chatId = ctx.chat.id;
+      ctx.reply(
+        `Chat ID: \`${chatId}\`\n\n` + `웹사이트의 알림 설정 페이지에서 이 ID를 입력하세요.`,
+        { parse_mode: 'Markdown' },
+      );
+      this.logger.log(`Telegram /start from chat ${chatId}`);
+    });
+
+    this.bot.launch({ dropPendingUpdates: true });
+    this.logger.log('Telegram bot started (polling mode)');
+  }
+
+  async onModuleDestroy() {
+    if (this.bot) {
+      this.bot.stop('shutdown');
+    }
+  }
+
+  async sendNotification(chatId: string, title: string, message: string): Promise<boolean> {
+    if (!this.bot) return false;
+
+    try {
+      await this.bot.telegram.sendMessage(chatId, `*${title}*\n${message}`, {
+        parse_mode: 'Markdown',
+      });
+      return true;
+    } catch (err) {
+      this.logger.error(`Telegram send failed to ${chatId}: ${err}`);
+      return false;
+    }
+  }
+}

--- a/apps/api-server/src/portfolio/portfolio.controller.ts
+++ b/apps/api-server/src/portfolio/portfolio.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PortfolioService } from './portfolio.service';
+import type { User } from '@coin/database';
+
+@Controller('portfolio')
+export class PortfolioController {
+  constructor(private readonly service: PortfolioService) {}
+
+  @Get('summary')
+  async getSummary(@CurrentUser() user: User): Promise<unknown> {
+    return this.service.getSummary(user.id);
+  }
+}

--- a/apps/api-server/src/portfolio/portfolio.module.ts
+++ b/apps/api-server/src/portfolio/portfolio.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PortfolioController } from './portfolio.controller';
+import { PortfolioService } from './portfolio.service';
+
+@Module({
+  controllers: [PortfolioController],
+  providers: [PortfolioService],
+})
+export class PortfolioModule {}

--- a/apps/api-server/src/portfolio/portfolio.service.ts
+++ b/apps/api-server/src/portfolio/portfolio.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
+import { UpbitRest, BinanceRest, BybitRest, IExchangeRest } from '@coin/exchange-adapters';
+import type { ExchangeId, ExchangeCredentials, Ticker } from '@coin/types';
+import { decrypt } from '@coin/utils';
+
+const REST_ADAPTERS: Record<ExchangeId, () => IExchangeRest> = {
+  upbit: () => new UpbitRest(),
+  binance: () => new BinanceRest(),
+  bybit: () => new BybitRest(),
+};
+
+interface PortfolioAsset {
+  exchange: string;
+  currency: string;
+  quantity: string;
+  avgCost: number;
+  currentPrice: number;
+  valueKrw: number;
+  pnl: number;
+}
+
+@Injectable()
+export class PortfolioService {
+  private readonly logger = new Logger(PortfolioService.name);
+  private redis: Redis;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+  }
+
+  async getSummary(userId: string) {
+    const masterKey = this.config.getOrThrow<string>('ENCRYPTION_MASTER_KEY');
+
+    // 1. Fetch balances from all exchange keys
+    const keys = await this.prisma.exchangeKey.findMany({
+      where: { userId },
+    });
+
+    const assets: PortfolioAsset[] = [];
+
+    for (const key of keys) {
+      try {
+        const credentials: ExchangeCredentials = {
+          apiKey: decrypt(key.apiKey, masterKey),
+          secretKey: decrypt(key.secretKey, masterKey),
+        };
+        const adapter = REST_ADAPTERS[key.exchange as ExchangeId]();
+        const balances = await adapter.getBalances(credentials);
+
+        for (const bal of balances) {
+          const free = parseFloat(bal.free);
+          const locked = parseFloat(bal.locked);
+          const total = free + locked;
+          if (total <= 0) continue;
+
+          const currentPrice = await this.getTickerPrice(key.exchange, bal.currency);
+          const avgCost = await this.getAvgCost(userId, key.exchange, bal.currency);
+
+          const valueKrw = currentPrice * total;
+          const pnl = avgCost > 0 ? (currentPrice - avgCost) * total : 0;
+
+          assets.push({
+            exchange: key.exchange,
+            currency: bal.currency,
+            quantity: total.toString(),
+            avgCost,
+            currentPrice,
+            valueKrw,
+            pnl,
+          });
+        }
+      } catch (err) {
+        this.logger.warn(`Failed to fetch balances for ${key.exchange}: ${err}`);
+      }
+    }
+
+    // 2. Calculate realized P&L from filled orders
+    const realizedPnl = await this.calculateRealizedPnl(userId);
+
+    // 3. Calculate daily P&L from orders
+    const dailyPnl = await this.calculateDailyPnl(userId);
+
+    const totalValueKrw = assets.reduce((sum, a) => sum + a.valueKrw, 0);
+    const unrealizedPnl = assets.reduce((sum, a) => sum + a.pnl, 0);
+
+    return { totalValueKrw, realizedPnl, unrealizedPnl, assets, dailyPnl };
+  }
+
+  private async getTickerPrice(exchange: string, currency: string): Promise<number> {
+    // Try common symbol patterns
+    const symbols =
+      exchange === 'upbit' ? [`KRW-${currency}`] : [`${currency}USDT`, `${currency}USD`];
+
+    for (const symbol of symbols) {
+      const key = `ticker:${exchange}:${symbol}`;
+      const data = await this.redis.get(key);
+      if (data) {
+        const ticker: Ticker = JSON.parse(data);
+        return parseFloat(ticker.price);
+      }
+    }
+
+    // Base currencies (KRW, USDT) have value 1
+    if (['KRW', 'USDT', 'USD'].includes(currency)) return 1;
+
+    return 0;
+  }
+
+  private async getAvgCost(userId: string, exchange: string, currency: string): Promise<number> {
+    // Find buy orders for this currency on this exchange
+    const buyOrders = await this.prisma.order.findMany({
+      where: {
+        userId,
+        exchange,
+        side: 'buy',
+        status: 'filled',
+        symbol: { contains: currency },
+      },
+    });
+
+    let totalCost = 0;
+    let totalQty = 0;
+    for (const order of buyOrders) {
+      const qty = parseFloat(order.filledQuantity);
+      const price = parseFloat(order.filledPrice);
+      if (qty > 0 && price > 0) {
+        totalCost += qty * price;
+        totalQty += qty;
+      }
+    }
+
+    return totalQty > 0 ? totalCost / totalQty : 0;
+  }
+
+  private async calculateRealizedPnl(userId: string): Promise<number> {
+    const sellOrders = await this.prisma.order.findMany({
+      where: { userId, side: 'sell', status: 'filled' },
+    });
+
+    let realized = 0;
+    for (const order of sellOrders) {
+      const qty = parseFloat(order.filledQuantity);
+      const price = parseFloat(order.filledPrice);
+      const fee = parseFloat(order.fee);
+
+      // Get average cost for this symbol
+      const parts = order.symbol.split('-');
+      const currency = parts.length > 1 ? parts[1] : parts[0].replace('USDT', '');
+      const avgCost = await this.getAvgCost(userId, order.exchange, currency);
+
+      if (avgCost > 0) {
+        realized += (price - avgCost) * qty - fee;
+      }
+    }
+
+    return Math.round(realized * 100) / 100;
+  }
+
+  private async calculateDailyPnl(userId: string): Promise<Array<{ date: string; pnl: number }>> {
+    const orders = await this.prisma.order.findMany({
+      where: { userId, status: 'filled' },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const dailyMap = new Map<string, number>();
+
+    for (const order of orders) {
+      const date = order.createdAt.toISOString().split('T')[0];
+      const qty = parseFloat(order.filledQuantity);
+      const price = parseFloat(order.filledPrice);
+      const fee = parseFloat(order.fee);
+      const value = qty * price;
+
+      const current = dailyMap.get(date) || 0;
+      if (order.side === 'sell') {
+        dailyMap.set(date, current + value - fee);
+      } else {
+        dailyMap.set(date, current - value - fee);
+      }
+    }
+
+    // Cumulative P&L
+    let cumulative = 0;
+    return Array.from(dailyMap.entries()).map(([date, pnl]) => {
+      cumulative += pnl;
+      return { date, pnl: Math.round(cumulative * 100) / 100 };
+    });
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { NavBar } from '@/components/nav-bar';
 import { AuthDebug } from '@/components/auth-debug';
+import { ToastContainer } from '@/components/toast';
 import { Providers } from './providers';
 
 export const metadata: Metadata = {
@@ -36,6 +37,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Providers>
           <NavBar />
           <main>{children}</main>
+          <ToastContainer />
           <AuthDebug accessTtl={accessTtl} />
         </Providers>
       </body>

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { getNotificationSettings, updateNotificationSettings } from '@/lib/api-client';
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm">{label}</span>
+      <button
+        type="button"
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+          checked ? 'bg-green-500' : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            checked ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export default function NotificationsPage() {
+  const queryClient = useQueryClient();
+  const [chatId, setChatId] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ['notificationSettings'],
+    queryFn: getNotificationSettings,
+  });
+
+  const mutation = useMutation({
+    mutationFn: updateNotificationSettings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notificationSettings'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="max-w-2xl mx-auto p-4">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Notification Settings</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Telegram</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="text-sm text-muted-foreground">
+            <p>1. Telegram에서 봇을 검색하고 /start를 보내세요</p>
+            <p>2. 봇이 알려주는 Chat ID를 아래에 입력하세요</p>
+          </div>
+          <div className="flex gap-2">
+            <Input
+              value={chatId || settings?.telegramChatId || ''}
+              onChange={(e) => setChatId(e.target.value)}
+              placeholder="Chat ID (예: 123456789)"
+            />
+            <Button
+              onClick={() =>
+                mutation.mutate({
+                  telegramChatId: chatId || settings?.telegramChatId || '',
+                })
+              }
+              disabled={mutation.isPending}
+              size="sm"
+            >
+              {mutation.isPending ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+          {settings?.telegramChatId && (
+            <p className="text-xs text-green-600">Connected: {settings.telegramChatId}</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Notification Types</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Toggle
+            label="Order Filled / Failed"
+            checked={settings?.notifyOrders ?? true}
+            onChange={(v) => mutation.mutate({ notifyOrders: v })}
+          />
+          <Toggle
+            label="Strategy Signals"
+            checked={settings?.notifySignals ?? true}
+            onChange={(v) => mutation.mutate({ notifySignals: v })}
+          />
+          <Toggle
+            label="Risk Blocked"
+            checked={settings?.notifyRisks ?? false}
+            onChange={(v) => mutation.mutate({ notifyRisks: v })}
+          />
+          {saved && <p className="text-xs text-green-600 mt-2">Settings saved</p>}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/portfolio/page.tsx
+++ b/apps/web/src/app/portfolio/page.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { getPortfolioSummary, type PortfolioAsset } from '@/lib/api-client';
+import { createChart, ColorType, type IChartApi } from 'lightweight-charts';
+
+function formatKrw(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)}M`;
+  }
+  return value.toLocaleString('ko-KR', { maximumFractionDigits: 0 });
+}
+
+function PnlValue({ value, prefix = '' }: { value: number; prefix?: string }) {
+  const color = value > 0 ? 'text-green-600' : value < 0 ? 'text-red-600' : 'text-muted-foreground';
+  const sign = value > 0 ? '+' : '';
+  return (
+    <span className={`font-bold ${color}`}>
+      {prefix}
+      {sign}
+      {formatKrw(value)}
+    </span>
+  );
+}
+
+function PnlChart({ data }: { data: Array<{ date: string; pnl: number }> }) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstance = useRef<IChartApi | null>(null);
+
+  useEffect(() => {
+    if (!chartRef.current || data.length === 0) return;
+
+    const chart = createChart(chartRef.current, {
+      width: chartRef.current.clientWidth,
+      height: 250,
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: '#9ca3af',
+      },
+      grid: {
+        vertLines: { color: '#f3f4f6' },
+        horzLines: { color: '#f3f4f6' },
+      },
+      rightPriceScale: { borderVisible: false },
+      timeScale: { borderVisible: false },
+    });
+
+    const series = chart.addAreaSeries({
+      lineColor: '#3b82f6',
+      topColor: 'rgba(59,130,246,0.3)',
+      bottomColor: 'rgba(59,130,246,0.05)',
+      lineWidth: 2,
+    });
+
+    series.setData(
+      data.map((d) => ({
+        time: d.date,
+        value: d.pnl,
+      })),
+    );
+
+    chart.timeScale().fitContent();
+    chartInstance.current = chart;
+
+    const handleResize = () => {
+      if (chartRef.current) {
+        chart.applyOptions({ width: chartRef.current.clientWidth });
+      }
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      chart.remove();
+    };
+  }, [data]);
+
+  return <div ref={chartRef} />;
+}
+
+function AssetTable({ assets }: { assets: PortfolioAsset[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 font-medium">Exchange</th>
+            <th className="pb-2 font-medium">Currency</th>
+            <th className="pb-2 font-medium text-right">Quantity</th>
+            <th className="pb-2 font-medium text-right">Avg Cost</th>
+            <th className="pb-2 font-medium text-right">Current</th>
+            <th className="pb-2 font-medium text-right">Value</th>
+            <th className="pb-2 font-medium text-right">P&L</th>
+          </tr>
+        </thead>
+        <tbody>
+          {assets.map((a, i) => (
+            <tr key={`${a.exchange}-${a.currency}-${i}`} className="border-b last:border-0">
+              <td className="py-2 capitalize">{a.exchange}</td>
+              <td className="py-2 font-medium">{a.currency}</td>
+              <td className="py-2 text-right tabular-nums">{a.quantity}</td>
+              <td className="py-2 text-right tabular-nums">
+                {a.avgCost > 0 ? formatKrw(a.avgCost) : '-'}
+              </td>
+              <td className="py-2 text-right tabular-nums">
+                {a.currentPrice > 0 ? formatKrw(a.currentPrice) : '-'}
+              </td>
+              <td className="py-2 text-right tabular-nums">{formatKrw(a.valueKrw)}</td>
+              <td className="py-2 text-right">
+                <PnlValue value={a.pnl} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function PortfolioPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['portfolio'],
+    queryFn: getPortfolioSummary,
+    staleTime: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="max-w-6xl mx-auto p-4">
+        <p className="text-muted-foreground">Loading portfolio...</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="max-w-6xl mx-auto p-4">
+        <p className="text-muted-foreground">
+          No portfolio data. Register exchange keys in Accounts first.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Portfolio</h1>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardContent className="pt-4">
+            <p className="text-sm text-muted-foreground">Total Value</p>
+            <p className="text-2xl font-bold">{formatKrw(data.totalValueKrw)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <p className="text-sm text-muted-foreground">Realized P&L</p>
+            <p className="text-2xl">
+              <PnlValue value={data.realizedPnl} />
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <p className="text-sm text-muted-foreground">Unrealized P&L</p>
+            <p className="text-2xl">
+              <PnlValue value={data.unrealizedPnl} />
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* P&L Chart */}
+      {data.dailyPnl.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Cumulative P&L</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <PnlChart data={data.dailyPnl} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Assets Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Assets</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {data.assets.length > 0 ? (
+            <AssetTable assets={data.assets} />
+          ) : (
+            <p className="text-center text-muted-foreground py-8">No assets found</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/nav-bar.tsx
+++ b/apps/web/src/components/nav-bar.tsx
@@ -30,10 +30,22 @@ export function NavBar() {
                 Strategies
               </Link>
               <Link
+                href="/portfolio"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                Portfolio
+              </Link>
+              <Link
                 href="/accounts"
                 className="text-sm text-muted-foreground hover:text-foreground"
               >
                 Accounts
+              </Link>
+              <Link
+                href="/notifications"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                Alerts
               </Link>
             </>
           )}

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useToastStore, type Toast } from '@/stores/use-toast-store';
+
+const TYPE_STYLES: Record<string, string> = {
+  success: 'border-green-500 bg-green-50 text-green-900',
+  warning: 'border-yellow-500 bg-yellow-50 text-yellow-900',
+  error: 'border-red-500 bg-red-50 text-red-900',
+  info: 'border-blue-500 bg-blue-50 text-blue-900',
+};
+
+function ToastItem({ toast, onClose }: { toast: Toast; onClose: () => void }) {
+  return (
+    <div
+      className={`border-l-4 rounded-r-lg p-3 shadow-lg max-w-sm animate-in slide-in-from-right ${TYPE_STYLES[toast.type] || TYPE_STYLES.info}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold">{toast.title}</p>
+          <p className="text-xs mt-0.5 opacity-80">{toast.message}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-current opacity-50 hover:opacity-100 text-sm"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+  const removeToast = useToastStore((s) => s.removeToast);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed top-16 right-4 z-50 flex flex-col gap-2">
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onClose={() => removeToast(toast.id)} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -339,3 +339,56 @@ export async function getStrategyLogs(
   if (!res.ok) throw new Error('Failed to fetch strategy logs');
   return res.json();
 }
+
+// --- Notifications ---
+
+export interface NotificationSettingItem {
+  telegramChatId: string | null;
+  notifyOrders: boolean;
+  notifySignals: boolean;
+  notifyRisks: boolean;
+}
+
+export async function getNotificationSettings(): Promise<NotificationSettingItem> {
+  const res = await apiFetch('/notifications/settings');
+  if (!res.ok) throw new Error('Failed to fetch notification settings');
+  return res.json();
+}
+
+export async function updateNotificationSettings(
+  data: Partial<NotificationSettingItem>,
+): Promise<NotificationSettingItem> {
+  const res = await apiFetch('/notifications/settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update notification settings');
+  return res.json();
+}
+
+// --- Portfolio ---
+
+export interface PortfolioAsset {
+  exchange: string;
+  currency: string;
+  quantity: string;
+  avgCost: number;
+  currentPrice: number;
+  valueKrw: number;
+  pnl: number;
+}
+
+export interface PortfolioSummary {
+  totalValueKrw: number;
+  realizedPnl: number;
+  unrealizedPnl: number;
+  assets: PortfolioAsset[];
+  dailyPnl: Array<{ date: string; pnl: number }>;
+}
+
+export async function getPortfolioSummary(): Promise<PortfolioSummary> {
+  const res = await apiFetch('/portfolio/summary');
+  if (!res.ok) throw new Error('Failed to fetch portfolio');
+  return res.json();
+}

--- a/apps/web/src/stores/use-order-updates-store.ts
+++ b/apps/web/src/stores/use-order-updates-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { io, Socket } from 'socket.io-client';
 import type { QueryClient } from '@tanstack/react-query';
+import { useToastStore } from './use-toast-store';
 
 interface OrderUpdatesState {
   _socket: Socket | null;
@@ -44,6 +45,20 @@ export const useOrderUpdatesStore = create<OrderUpdatesState>((set, get) => ({
 
     socket.on('strategy:signal', () => {
       queryClient.invalidateQueries({ queryKey: ['strategies'] });
+    });
+
+    socket.on('notification:received', (data: { type: string; title: string; message: string }) => {
+      const toastType =
+        data.type === 'order_filled' || data.type === 'strategy_signal'
+          ? 'success'
+          : data.type === 'order_failed'
+            ? 'error'
+            : 'warning';
+      useToastStore.getState().addToast({
+        type: toastType,
+        title: data.title,
+        message: data.message,
+      });
     });
 
     set({ _socket: socket, _userId: userId });

--- a/apps/web/src/stores/use-toast-store.ts
+++ b/apps/web/src/stores/use-toast-store.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+
+export interface Toast {
+  id: string;
+  type: 'success' | 'warning' | 'error' | 'info';
+  title: string;
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, 'id'>) => void;
+  removeToast: (id: string) => void;
+}
+
+let toastId = 0;
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+
+  addToast: (toast) => {
+    const id = String(++toastId);
+    set((state) => ({ toasts: [...state.toasts, { ...toast, id }] }));
+
+    setTimeout(() => {
+      set((state) => ({
+        toasts: state.toasts.filter((t) => t.id !== id),
+      }));
+    }, 5000);
+  },
+
+  removeToast: (id) => {
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.id !== id),
+    }));
+  },
+}));

--- a/apps/worker-service/Dockerfile
+++ b/apps/worker-service/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=deps /app ./
 COPY . .
 RUN pnpm install --frozen-lockfile
 WORKDIR /app/apps/worker-service
-CMD ["sh", "-c", "pnpm --filter @coin/database db:generate && pnpm --filter @coin/database build && pnpm dev"]
+CMD ["sh", "-c", "pnpm --filter @coin/database db:generate && pnpm --filter @coin/database build && pnpm --filter @coin/kafka-contracts build && pnpm dev"]
 
 # Build + deploy
 FROM base AS builder

--- a/apps/worker-service/src/strategies/strategies.service.ts
+++ b/apps/worker-service/src/strategies/strategies.service.ts
@@ -2,7 +2,11 @@ import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/commo
 import { Kafka, Producer } from 'kafkajs';
 import Redis from 'ioredis';
 import { KAFKA_TOPICS } from '@coin/kafka-contracts';
-import type { StrategySignalEvent, OrderRequestedEvent } from '@coin/kafka-contracts';
+import type {
+  StrategySignalEvent,
+  OrderRequestedEvent,
+  NotificationEvent,
+} from '@coin/kafka-contracts';
 import type { ExchangeId } from '@coin/types';
 import { PrismaService } from '../prisma/prisma.service';
 import { RiskService, type RiskConfig } from './risk/risk.service';
@@ -170,6 +174,18 @@ export class StrategiesService implements OnModuleInit, OnModuleDestroy {
           riskReason: riskResult.reason,
           price: currentPrice,
         });
+
+        const riskNotif: NotificationEvent = {
+          userId: strategy.userId,
+          type: 'risk_blocked',
+          title: `리스크 차단 | ${strategy.name}`,
+          message: `${evaluation.signal.toUpperCase()} 차단 — ${riskResult.reason}`,
+        };
+        await this.producer.send({
+          topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+          messages: [{ key: strategy.userId, value: JSON.stringify(riskNotif) }],
+        });
+
         this.logger.log(
           `Strategy ${strategy.name}: ${evaluation.signal} blocked by risk - ${riskResult.reason}`,
         );
@@ -199,6 +215,17 @@ export class StrategiesService implements OnModuleInit, OnModuleDestroy {
           ...evaluation.indicatorValues,
           price: currentPrice,
           reason: evaluation.reason,
+        });
+
+        const signalNotif: NotificationEvent = {
+          userId: strategy.userId,
+          type: 'strategy_signal',
+          title: `전략 신호 | ${strategy.name}`,
+          message: `${evaluation.signal.toUpperCase()} — ${evaluation.reason}`,
+        };
+        await this.producer.send({
+          topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+          messages: [{ key: strategy.userId, value: JSON.stringify(signalNotif) }],
         });
 
         this.logger.log(`Strategy ${strategy.name}: ${evaluation.signal} signal sent`);

--- a/packages/database/prisma/migrations/20260325082243_add_notification_setting/migration.sql
+++ b/packages/database/prisma/migrations/20260325082243_add_notification_setting/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "NotificationSetting" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "telegramChatId" TEXT,
+    "notifyOrders" BOOLEAN NOT NULL DEFAULT true,
+    "notifySignals" BOOLEAN NOT NULL DEFAULT true,
+    "notifyRisks" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationSetting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationSetting_userId_key" ON "NotificationSetting"("userId");
+
+-- AddForeignKey
+ALTER TABLE "NotificationSetting" ADD CONSTRAINT "NotificationSetting_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -18,8 +18,9 @@ model User {
   accounts      Account[]
   refreshTokens RefreshToken[]
   exchangeKeys  ExchangeKey[]
-  orders        Order[]
-  strategies    Strategy[]
+  orders              Order[]
+  strategies          Strategy[]
+  notificationSetting NotificationSetting?
 }
 
 model Account {
@@ -126,4 +127,16 @@ model StrategyLog {
 
   @@index([strategyId])
   @@index([strategyId, createdAt])
+}
+
+model NotificationSetting {
+  id             String   @id @default(cuid())
+  userId         String   @unique
+  telegramChatId String?
+  notifyOrders   Boolean  @default(true)
+  notifySignals  Boolean  @default(true)
+  notifyRisks    Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/packages/kafka-contracts/src/events.ts
+++ b/packages/kafka-contracts/src/events.ts
@@ -28,3 +28,11 @@ export interface StrategySignalEvent {
   reason: string;
   timestamp: number;
 }
+
+export interface NotificationEvent {
+  userId: string;
+  type: 'order_filled' | 'order_failed' | 'strategy_signal' | 'risk_blocked';
+  title: string;
+  message: string;
+  data?: Record<string, unknown>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       socket.io:
         specifier: ^4
         version: 4.8.3
+      telegraf:
+        specifier: ^4.16.3
+        version: 4.16.3
     devDependencies:
       '@coin/tsconfig':
         specifier: workspace:*
@@ -1482,6 +1485,12 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@telegraf/types@7.1.0':
+    resolution:
+      {
+        integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==,
+      }
+
   '@tokenizer/inflate@0.4.1':
     resolution:
       {
@@ -1930,6 +1939,13 @@ packages:
         integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==,
       }
 
+  abort-controller@3.0.0:
+    resolution:
+      {
+        integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==,
+      }
+    engines: { node: '>=6.5' }
+
   accepts@1.3.8:
     resolution:
       {
@@ -2174,10 +2190,28 @@ packages:
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
 
+  buffer-alloc-unsafe@1.1.0:
+    resolution:
+      {
+        integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==,
+      }
+
+  buffer-alloc@1.2.0:
+    resolution:
+      {
+        integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==,
+      }
+
   buffer-equal-constant-time@1.0.1:
     resolution:
       {
         integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==,
+      }
+
+  buffer-fill@1.0.0:
+    resolution:
+      {
+        integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==,
       }
 
   buffer-from@1.1.2:
@@ -2887,6 +2921,13 @@ packages:
         integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
       }
     engines: { node: '>= 0.6' }
+
+  event-target-shim@5.0.1:
+    resolution:
+      {
+        integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==,
+      }
+    engines: { node: '>=6' }
 
   eventemitter3@5.0.4:
     resolution:
@@ -3783,6 +3824,13 @@ packages:
       }
     engines: { node: '>=16 || 14 >=14.17' }
 
+  mri@1.2.0:
+    resolution:
+      {
+        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
+      }
+    engines: { node: '>=4' }
+
   ms@2.1.3:
     resolution:
       {
@@ -3885,6 +3933,18 @@ packages:
       {
         integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
       }
+
+  node-fetch@2.7.0:
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-gyp-build@4.8.4:
     resolution:
@@ -3998,6 +4058,13 @@ packages:
     resolution:
       {
         integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: '>=10' }
+
+  p-timeout@4.1.0:
+    resolution:
+      {
+        integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==,
       }
     engines: { node: '>=10' }
 
@@ -4378,11 +4445,24 @@ packages:
         integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
       }
 
+  safe-compare@1.1.4:
+    resolution:
+      {
+        integrity: sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==,
+      }
+
   safer-buffer@2.1.2:
     resolution:
       {
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
+
+  sandwich-stream@2.0.2:
+    resolution:
+      {
+        integrity: sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==,
+      }
+    engines: { node: '>= 0.10' }
 
   scheduler@0.27.0:
     resolution:
@@ -4720,6 +4800,14 @@ packages:
         integrity: sha512-f16mOc+Y05hNy/of+UbGxhxQQmxUztCiluhsqC5QLUYz4WowUgKde9m6nIjK1Kay0wGHigT0IkOabpp0+22UfA==,
       }
 
+  telegraf@4.16.3:
+    resolution:
+      {
+        integrity: sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==,
+      }
+    engines: { node: ^12.20.0 || >=14.13.1 }
+    hasBin: true
+
   terser-webpack-plugin@5.4.0:
     resolution:
       {
@@ -4774,6 +4862,12 @@ packages:
         integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==,
       }
     engines: { node: '>=14.16' }
+
+  tr46@0.0.3:
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
 
   ts-api-utils@2.5.0:
     resolution:
@@ -4948,6 +5042,12 @@ packages:
         integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==,
       }
 
+  webidl-conversions@3.0.1:
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+      }
+
   webpack-node-externals@3.0.0:
     resolution:
       {
@@ -4974,6 +5074,12 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-url@5.0.0:
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which@2.0.2:
     resolution:
@@ -5766,6 +5872,8 @@ snapshots:
       '@tanstack/query-core': 5.95.2
       react: 19.2.4
 
+  '@telegraf/types@7.1.0': {}
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -6092,6 +6200,10 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -6228,7 +6340,16 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer-alloc-unsafe@1.1.0: {}
+
+  buffer-alloc@1.2.0:
+    dependencies:
+      buffer-alloc-unsafe: 1.1.0
+      buffer-fill: 1.0.0
+
   buffer-equal-constant-time@1.0.1: {}
+
+  buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -6617,6 +6738,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.4: {}
 
@@ -7113,6 +7236,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   multer@2.1.1:
@@ -7166,6 +7291,10 @@ snapshots:
       lodash: 4.17.23
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
 
@@ -7233,6 +7362,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-timeout@4.1.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -7441,7 +7572,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-compare@1.1.4:
+    dependencies:
+      buffer-alloc: 1.2.0
+
   safer-buffer@2.1.2: {}
+
+  sandwich-stream@2.0.2: {}
 
   scheduler@0.27.0: {}
 
@@ -7693,6 +7830,20 @@ snapshots:
     dependencies:
       '@types/node': 6.14.13
 
+  telegraf@4.16.3:
+    dependencies:
+      '@telegraf/types': 7.1.0
+      abort-controller: 3.0.0
+      debug: 4.4.3
+      mri: 1.2.0
+      node-fetch: 2.7.0
+      p-timeout: 4.1.0
+      safe-compare: 1.1.4
+      sandwich-stream: 2.0.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   terser-webpack-plugin@5.4.0(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -7722,6 +7873,8 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tr46@0.0.3: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -7813,6 +7966,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webidl-conversions@3.0.1: {}
+
   webpack-node-externals@3.0.0: {}
 
   webpack-sources@3.3.4: {}
@@ -7848,6 +8003,11 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Telegram 봇 알림 (telegraf, polling 모드, /start 명령어로 chat ID 안내)
- WebSocket 실시간 토스트 알림 (notification:received 이벤트)
- Kafka NOTIFICATION_SEND 파이프라인 (주문 체결/실패, 전략 시그널, 리스크 차단)
- 알림 설정 UI (Telegram chat ID, 유형별 on/off 토글)
- 포트폴리오 대시보드 (통합 잔고, 실현/미실현 P&L, lightweight-charts 차트)
- Phase 7 프로덕션 최적화 이슈 생성 (#22)

## Test plan
- [x] Docker 빌드 성공, 전체 서비스 정상 기동
- [x] Telegram bot started (polling mode) 로그 확인
- [x] Notification consumer started 로그 확인
- [x] 알림 설정 API (GET/PATCH) 정상 동작
- [x] 포트폴리오 API (GET /portfolio/summary) 정상 동작
- [x] 텔레그램 알림 수신 테스트 (실제 chat ID 필요)
- [x] 브라우저 토스트 알림 확인

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a real-time user notification system and a portfolio dashboard across API, web, and worker services.

New Features:
- Introduce user-configurable notification settings with Telegram chat ID support and per-type toggles.
- Send notifications for order events, strategy signals, and risk blocks via Kafka and WebSocket toasts.
- Add a portfolio dashboard showing aggregated balances, realized/unrealized P&L, and historical P&L chart.

Enhancements:
- Integrate a Telegram bot for delivering trading notifications to users.
- Expose portfolio summary and notification settings APIs in the API server.
- Wire notifications into existing Kafka pipelines in markets and strategy services.
- Add a reusable toast UI and store for in-browser alert display.

Build:
- Ensure kafka-contracts package is built in API server and worker Docker images.