### PR TITLE
fix: add docker/setup-buildx-action for GHCR build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -44,6 +44,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -70,6 +71,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -96,6 +98,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Summary
- GHA cache(`cache-from/to: type=gha`)는 docker-container buildx 드라이버가 필요
- 3개 빌드 job에 `docker/setup-buildx-action@v3` 추가

## Test plan
- [ ] main 머지 후 build-and-push 워크플로우 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add docker/setup-buildx-action to each GHCR build job in the build-and-push workflow.