### PR TITLE
fix: build-and-push workflow_dispatch + paths-filter fix

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,6 +3,7 @@ name: Build & Push Images
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -17,6 +18,8 @@ jobs:
       worker-service: ${{ steps.filter.outputs.worker-service }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Summary
- `workflow_dispatch` 트리거 추가 (수동 실행 가능)
- `fetch-depth: 2` 추가 (paths-filter가 이전 커밋과 비교 가능하도록)

머지 후 Actions 탭에서 수동 실행으로 첫 GHCR 빌드를 트리거할 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add manual dispatch support and fix path filtering reliability for the image build-and-push workflow.

CI:
- Allow the build-and-push workflow to be triggered manually via workflow_dispatch.
- Ensure paths-filter has sufficient git history by increasing checkout fetch depth.