### PR TITLE
fix: build all images on workflow_dispatch

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -40,7 +40,7 @@ jobs:
 
   build-api-server:
     needs: changes
-    if: needs.changes.outputs.api-server == 'true'
+    if: needs.changes.outputs.api-server == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
 
   build-web:
     needs: changes
-    if: needs.changes.outputs.web == 'true'
+    if: needs.changes.outputs.web == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -94,7 +94,7 @@ jobs:
 
   build-worker-service:
     needs: changes
-    if: needs.changes.outputs.worker-service == 'true'
+    if: needs.changes.outputs.worker-service == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- `workflow_dispatch` 수동 실행 시 paths-filter를 무시하고 모든 앱 이미지를 빌드하도록 수정

머지 후 Actions → "Build & Push Images" → "Run workflow" 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)