### PR TITLE
test: add api-server CQRS handler tests (9 commands + 10 queries)

### DIFF
--- a/apps/api-server/src/exchange-keys/commands/create-exchange-key.handler.test.ts
+++ b/apps/api-server/src/exchange-keys/commands/create-exchange-key.handler.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { CreateExchangeKeyCommand } from './create-exchange-key.command';
+
+const mockGetBalances = vi.fn().mockResolvedValue([]);
+
+// Mock exchange adapters with class constructors
+vi.mock('@coin/exchange-adapters', () => {
+  class MockAdapter {
+    getBalances = mockGetBalances;
+  }
+  return {
+    UpbitRest: MockAdapter,
+    BinanceRest: MockAdapter,
+    BybitRest: MockAdapter,
+  };
+});
+
+// Import after mock
+const { CreateExchangeKeyHandler } = await import('./create-exchange-key.handler');
+
+const mockPrisma = {
+  exchangeKey: { upsert: vi.fn() },
+};
+const mockConfig = {
+  getOrThrow: vi.fn().mockReturnValue('a'.repeat(64)),
+};
+
+describe('CreateExchangeKeyHandler', () => {
+  let handler: InstanceType<typeof CreateExchangeKeyHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig.getOrThrow.mockReturnValue('a'.repeat(64));
+    mockGetBalances.mockResolvedValue([]);
+    handler = new CreateExchangeKeyHandler(mockPrisma as never, mockConfig as never);
+  });
+
+  it('should create/upsert an exchange key with encrypted credentials', async () => {
+    mockPrisma.exchangeKey.upsert.mockResolvedValue({
+      id: 'key-1',
+      exchange: 'upbit',
+      createdAt: new Date(),
+    });
+
+    const result = await handler.execute(
+      new CreateExchangeKeyCommand('user-1', {
+        exchange: 'upbit',
+        apiKey: 'my-api-key',
+        secretKey: 'my-secret',
+      } as never),
+    );
+
+    expect(result).toHaveProperty('id', 'key-1');
+    const upsertCall = mockPrisma.exchangeKey.upsert.mock.calls[0][0];
+    expect(upsertCall.create.apiKey).not.toBe('my-api-key');
+    expect(upsertCall.create.secretKey).not.toBe('my-secret');
+  });
+
+  it('should throw if ENCRYPTION_MASTER_KEY is not configured', async () => {
+    mockConfig.getOrThrow.mockImplementation(() => {
+      throw new Error('Missing ENCRYPTION_MASTER_KEY');
+    });
+
+    await expect(
+      handler.execute(
+        new CreateExchangeKeyCommand('user-1', {
+          exchange: 'upbit',
+          apiKey: 'key',
+          secretKey: 'secret',
+        } as never),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('should throw BadRequestException if API validation fails', async () => {
+    mockGetBalances.mockRejectedValue(new Error('Invalid API key'));
+
+    await expect(
+      handler.execute(
+        new CreateExchangeKeyCommand('user-1', {
+          exchange: 'upbit',
+          apiKey: 'bad-key',
+          secretKey: 'bad-secret',
+        } as never),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api-server/src/exchange-keys/commands/delete-exchange-key.handler.test.ts
+++ b/apps/api-server/src/exchange-keys/commands/delete-exchange-key.handler.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { DeleteExchangeKeyHandler } from './delete-exchange-key.handler';
+import { DeleteExchangeKeyCommand } from './delete-exchange-key.command';
+
+const mockPrisma = {
+  exchangeKey: { findFirst: vi.fn(), delete: vi.fn() },
+};
+
+describe('DeleteExchangeKeyHandler', () => {
+  let handler: DeleteExchangeKeyHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new DeleteExchangeKeyHandler(mockPrisma as never);
+  });
+
+  it('should delete an exchange key', async () => {
+    mockPrisma.exchangeKey.findFirst.mockResolvedValue({ id: 'key-1' });
+    mockPrisma.exchangeKey.delete.mockResolvedValue({ id: 'key-1' });
+
+    const result = await handler.execute(new DeleteExchangeKeyCommand('user-1', 'key-1'));
+    expect(result).toEqual({ message: 'Deleted' });
+  });
+
+  it('should throw if key not found', async () => {
+    mockPrisma.exchangeKey.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new DeleteExchangeKeyCommand('user-1', 'non-existent')),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api-server/src/exchange-keys/queries/get-exchange-keys.handler.test.ts
+++ b/apps/api-server/src/exchange-keys/queries/get-exchange-keys.handler.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetExchangeKeysHandler } from './get-exchange-keys.handler';
+import { GetExchangeKeysQuery } from './get-exchange-keys.query';
+
+const mockPrisma = { exchangeKey: { findMany: vi.fn() } };
+
+describe('GetExchangeKeysHandler', () => {
+  let handler: GetExchangeKeysHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetExchangeKeysHandler(mockPrisma as never);
+  });
+
+  it('should return exchange keys without sensitive data', async () => {
+    const keys = [{ id: 'key-1', exchange: 'upbit', createdAt: new Date() }];
+    mockPrisma.exchangeKey.findMany.mockResolvedValue(keys);
+
+    const result = await handler.execute(new GetExchangeKeysQuery('user-1'));
+    expect(result).toEqual(keys);
+    // Should select specific fields (no apiKey/secretKey)
+    const selectArg = mockPrisma.exchangeKey.findMany.mock.calls[0][0].select;
+    if (selectArg) {
+      expect(selectArg.apiKey).toBeUndefined();
+      expect(selectArg.secretKey).toBeUndefined();
+    }
+  });
+});

--- a/apps/api-server/src/notifications/commands/update-notification-setting.handler.test.ts
+++ b/apps/api-server/src/notifications/commands/update-notification-setting.handler.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateNotificationSettingHandler } from './update-notification-setting.handler';
+import { UpdateNotificationSettingCommand } from './update-notification-setting.command';
+
+const mockPrisma = {
+  notificationSetting: { upsert: vi.fn() },
+};
+
+describe('UpdateNotificationSettingHandler', () => {
+  let handler: UpdateNotificationSettingHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new UpdateNotificationSettingHandler(mockPrisma as never);
+  });
+
+  it('should upsert notification setting', async () => {
+    const setting = { id: 'ns-1', telegramChatId: '12345', notifyOrders: true };
+    mockPrisma.notificationSetting.upsert.mockResolvedValue(setting);
+
+    const result = await handler.execute(
+      new UpdateNotificationSettingCommand('user-1', {
+        telegramChatId: '12345',
+        notifyOrders: true,
+      } as never),
+    );
+
+    expect(result).toEqual(setting);
+    expect(mockPrisma.notificationSetting.upsert).toHaveBeenCalled();
+  });
+});

--- a/apps/api-server/src/notifications/queries/get-notification-settings.handler.test.ts
+++ b/apps/api-server/src/notifications/queries/get-notification-settings.handler.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetNotificationSettingsHandler } from './get-notification-settings.handler';
+import { GetNotificationSettingsQuery } from './get-notification-settings.query';
+
+const mockPrisma = { notificationSetting: { findUnique: vi.fn() } };
+
+describe('GetNotificationSettingsHandler', () => {
+  let handler: GetNotificationSettingsHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetNotificationSettingsHandler(mockPrisma as never);
+  });
+
+  it('should return existing settings', async () => {
+    const setting = {
+      telegramChatId: '12345',
+      notifyOrders: true,
+      notifySignals: false,
+      notifyRisks: true,
+    };
+    mockPrisma.notificationSetting.findUnique.mockResolvedValue(setting);
+
+    const result = await handler.execute(new GetNotificationSettingsQuery('user-1'));
+    expect(result).toEqual(setting);
+  });
+
+  it('should return defaults when no settings exist', async () => {
+    mockPrisma.notificationSetting.findUnique.mockResolvedValue(null);
+
+    const result = await handler.execute(new GetNotificationSettingsQuery('user-1'));
+    expect(result).toEqual({
+      telegramChatId: null,
+      notifyOrders: true,
+      notifySignals: true,
+      notifyRisks: false,
+    });
+  });
+});

--- a/apps/api-server/src/orders/commands/cancel-order.handler.test.ts
+++ b/apps/api-server/src/orders/commands/cancel-order.handler.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { CancelOrderHandler } from './cancel-order.handler';
+import { CancelOrderCommand } from './cancel-order.command';
+
+const mockPrisma = {
+  order: { findFirst: vi.fn(), update: vi.fn() },
+  exchangeKey: { findUnique: vi.fn() },
+};
+
+describe('CancelOrderHandler', () => {
+  let handler: CancelOrderHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new CancelOrderHandler(mockPrisma as never);
+  });
+
+  it('should cancel a pending paper order', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      id: 'order-1',
+      userId: 'user-1',
+      status: 'pending',
+      mode: 'paper',
+    });
+    mockPrisma.order.update.mockResolvedValue({ id: 'order-1', status: 'cancelled' });
+
+    const result = await handler.execute(new CancelOrderCommand('user-1', 'order-1'));
+    expect(result).toEqual({ id: 'order-1', status: 'cancelled' });
+  });
+
+  it('should throw if order not found', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue(null);
+
+    await expect(handler.execute(new CancelOrderCommand('user-1', 'non-existent'))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('should throw if order is already filled', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      id: 'order-1',
+      userId: 'user-1',
+      status: 'filled',
+    });
+
+    await expect(handler.execute(new CancelOrderCommand('user-1', 'order-1'))).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/apps/api-server/src/orders/commands/create-order.handler.test.ts
+++ b/apps/api-server/src/orders/commands/create-order.handler.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { CreateOrderHandler } from './create-order.handler';
+import { CreateOrderCommand } from './create-order.command';
+
+const mockPrisma = { exchangeKey: { findFirst: vi.fn() } };
+const mockOrchestrator = { startSaga: vi.fn() };
+
+describe('CreateOrderHandler', () => {
+  let handler: CreateOrderHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new CreateOrderHandler(mockPrisma as never, mockOrchestrator as never);
+  });
+
+  it('should create a paper market order', async () => {
+    mockOrchestrator.startSaga.mockResolvedValue({ id: 'order-1', status: 'pending' });
+
+    const result = await handler.execute(
+      new CreateOrderCommand('user-1', {
+        exchange: 'upbit',
+        symbol: 'KRW-BTC',
+        side: 'buy',
+        type: 'market',
+        mode: 'paper',
+        quantity: '0.001',
+      } as never),
+    );
+
+    expect(mockOrchestrator.startSaga).toHaveBeenCalled();
+    expect(result).toEqual({ id: 'order-1', status: 'pending' });
+  });
+
+  it('should require exchangeKeyId for real mode', async () => {
+    await expect(
+      handler.execute(
+        new CreateOrderCommand('user-1', {
+          exchange: 'upbit',
+          symbol: 'KRW-BTC',
+          side: 'buy',
+          type: 'market',
+          mode: 'real',
+          quantity: '0.001',
+        } as never),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('should validate exchange key exists for real mode', async () => {
+    mockPrisma.exchangeKey.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(
+        new CreateOrderCommand('user-1', {
+          exchange: 'upbit',
+          symbol: 'KRW-BTC',
+          side: 'buy',
+          type: 'market',
+          mode: 'real',
+          quantity: '0.001',
+          exchangeKeyId: 'key-1',
+        } as never),
+      ),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('should require price for limit orders', async () => {
+    await expect(
+      handler.execute(
+        new CreateOrderCommand('user-1', {
+          exchange: 'upbit',
+          symbol: 'KRW-BTC',
+          side: 'buy',
+          type: 'limit',
+          mode: 'paper',
+          quantity: '0.001',
+        } as never),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('should strip commas from quantity', async () => {
+    mockOrchestrator.startSaga.mockResolvedValue({ id: 'order-1' });
+
+    await handler.execute(
+      new CreateOrderCommand('user-1', {
+        exchange: 'upbit',
+        symbol: 'KRW-BTC',
+        side: 'buy',
+        type: 'market',
+        mode: 'paper',
+        quantity: '1,000.5',
+      } as never),
+    );
+
+    const callArgs = mockOrchestrator.startSaga.mock.calls[0];
+    expect(callArgs[1].quantity).toBe('1000.5');
+  });
+});

--- a/apps/api-server/src/orders/queries/get-order.handler.test.ts
+++ b/apps/api-server/src/orders/queries/get-order.handler.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { GetOrderHandler } from './get-order.handler';
+import { GetOrderQuery } from './get-order.query';
+
+const mockPrisma = { order: { findFirst: vi.fn() } };
+
+describe('GetOrderHandler', () => {
+  let handler: GetOrderHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetOrderHandler(mockPrisma as never);
+  });
+
+  it('should return an order', async () => {
+    const order = { id: 'order-1', userId: 'user-1', symbol: 'KRW-BTC' };
+    mockPrisma.order.findFirst.mockResolvedValue(order);
+
+    const result = await handler.execute(new GetOrderQuery('user-1', 'order-1'));
+    expect(result).toEqual(order);
+  });
+
+  it('should throw NotFoundException if not found', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue(null);
+
+    await expect(handler.execute(new GetOrderQuery('user-1', 'non-existent'))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});

--- a/apps/api-server/src/orders/queries/get-orders.handler.test.ts
+++ b/apps/api-server/src/orders/queries/get-orders.handler.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetOrdersHandler } from './get-orders.handler';
+import { GetOrdersQuery } from './get-orders.query';
+
+const mockPrisma = { order: { findMany: vi.fn() } };
+
+describe('GetOrdersHandler', () => {
+  let handler: GetOrdersHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetOrdersHandler(mockPrisma as never);
+  });
+
+  it('should return orders with pagination', async () => {
+    const orders = [
+      { id: '1', createdAt: new Date('2025-01-02') },
+      { id: '2', createdAt: new Date('2025-01-01') },
+    ];
+    mockPrisma.order.findMany.mockResolvedValue(orders);
+
+    const result = await handler.execute(new GetOrdersQuery('user-1', undefined, 20));
+    expect(result.items).toHaveLength(2);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('should return nextCursor when hasMore', async () => {
+    // Return limit + 1 items to indicate hasMore
+    const orders = Array.from({ length: 21 }, (_, i) => ({
+      id: `order-${i}`,
+      createdAt: new Date(2025, 0, 21 - i),
+    }));
+    mockPrisma.order.findMany.mockResolvedValue(orders);
+
+    const result = await handler.execute(new GetOrdersQuery('user-1', undefined, 20));
+    expect(result.items).toHaveLength(20);
+    expect(result.nextCursor).toBeDefined();
+  });
+
+  it('should apply filters', async () => {
+    mockPrisma.order.findMany.mockResolvedValue([]);
+
+    await handler.execute(
+      new GetOrdersQuery('user-1', undefined, 20, 'filled', 'upbit', 'KRW-BTC', 'paper', 'buy'),
+    );
+
+    const where = mockPrisma.order.findMany.mock.calls[0][0].where;
+    expect(where.userId).toBe('user-1');
+    expect(where.status).toBe('filled');
+    expect(where.exchange).toBe('upbit');
+    expect(where.symbol).toBe('KRW-BTC');
+    expect(where.mode).toBe('paper');
+    expect(where.side).toBe('buy');
+  });
+});

--- a/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.test.ts
+++ b/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetPortfolioSummaryHandler } from './get-portfolio-summary.handler';
+import { GetPortfolioSummaryQuery } from './get-portfolio-summary.query';
+
+const mockPortfolioService = { getSummary: vi.fn() };
+
+describe('GetPortfolioSummaryHandler', () => {
+  let handler: GetPortfolioSummaryHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetPortfolioSummaryHandler(mockPortfolioService as never);
+  });
+
+  it('should delegate to portfolioService.getSummary', async () => {
+    const summary = { totalValue: 1000, assets: [] };
+    mockPortfolioService.getSummary.mockResolvedValue(summary);
+
+    const result = await handler.execute(new GetPortfolioSummaryQuery('user-1', 'paper'));
+    expect(result).toEqual(summary);
+    expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', 'paper');
+  });
+
+  it('should pass mode "all" when not specified', async () => {
+    mockPortfolioService.getSummary.mockResolvedValue({});
+
+    await handler.execute(new GetPortfolioSummaryQuery('user-1'));
+    expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', undefined);
+  });
+});

--- a/apps/api-server/src/strategies/commands/create-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/create-strategy.handler.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { CreateStrategyHandler } from './create-strategy.handler';
+import { CreateStrategyCommand } from './create-strategy.command';
+
+const mockPrisma = {
+  exchangeKey: { findFirst: vi.fn() },
+  strategy: { create: vi.fn() },
+};
+
+describe('CreateStrategyHandler', () => {
+  let handler: CreateStrategyHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new CreateStrategyHandler(mockPrisma as never);
+  });
+
+  it('should create a paper strategy', async () => {
+    const created = { id: 'strat-1', name: 'RSI Test', type: 'rsi' };
+    mockPrisma.strategy.create.mockResolvedValue(created);
+
+    const result = await handler.execute(
+      new CreateStrategyCommand('user-1', {
+        name: 'RSI Test',
+        type: 'rsi',
+        exchange: 'upbit',
+        symbol: 'KRW-BTC',
+        mode: 'signal',
+        tradingMode: 'paper',
+        config: { period: 14 },
+      } as never),
+    );
+
+    expect(result).toEqual(created);
+    expect(mockPrisma.strategy.create).toHaveBeenCalled();
+  });
+
+  it('should require exchangeKeyId for real tradingMode', async () => {
+    await expect(
+      handler.execute(
+        new CreateStrategyCommand('user-1', {
+          name: 'Test',
+          type: 'rsi',
+          exchange: 'upbit',
+          symbol: 'KRW-BTC',
+          mode: 'signal',
+          tradingMode: 'real',
+          config: {},
+        } as never),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('should validate exchange key exists for real mode', async () => {
+    mockPrisma.exchangeKey.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(
+        new CreateStrategyCommand('user-1', {
+          name: 'Test',
+          type: 'rsi',
+          exchange: 'upbit',
+          symbol: 'KRW-BTC',
+          mode: 'signal',
+          tradingMode: 'real',
+          exchangeKeyId: 'key-1',
+          config: {},
+        } as never),
+      ),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api-server/src/strategies/commands/delete-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/delete-strategy.handler.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { DeleteStrategyHandler } from './delete-strategy.handler';
+import { DeleteStrategyCommand } from './delete-strategy.command';
+
+const mockPrisma = {
+  strategy: { findFirst: vi.fn(), delete: vi.fn() },
+};
+
+describe('DeleteStrategyHandler', () => {
+  let handler: DeleteStrategyHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new DeleteStrategyHandler(mockPrisma as never);
+  });
+
+  it('should delete a strategy', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
+    mockPrisma.strategy.delete.mockResolvedValue({ id: 'strat-1' });
+
+    const result = await handler.execute(new DeleteStrategyCommand('user-1', 'strat-1'));
+    expect(result).toEqual({ id: 'strat-1', deleted: true });
+  });
+
+  it('should throw if strategy not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new DeleteStrategyCommand('user-1', 'non-existent')),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api-server/src/strategies/commands/toggle-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/toggle-strategy.handler.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { ToggleStrategyHandler } from './toggle-strategy.handler';
+import { ToggleStrategyCommand } from './toggle-strategy.command';
+
+const mockPrisma = {
+  strategy: { findFirst: vi.fn(), update: vi.fn() },
+};
+
+describe('ToggleStrategyHandler', () => {
+  let handler: ToggleStrategyHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new ToggleStrategyHandler(mockPrisma as never);
+  });
+
+  it('should toggle enabled from false to true', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', enabled: false });
+    mockPrisma.strategy.update.mockResolvedValue({ id: 'strat-1', enabled: true });
+
+    const result = await handler.execute(new ToggleStrategyCommand('user-1', 'strat-1'));
+    expect(result).toEqual({ id: 'strat-1', enabled: true });
+    expect(mockPrisma.strategy.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { enabled: true } }),
+    );
+  });
+
+  it('should toggle enabled from true to false', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', enabled: true });
+    mockPrisma.strategy.update.mockResolvedValue({ id: 'strat-1', enabled: false });
+
+    const result = await handler.execute(new ToggleStrategyCommand('user-1', 'strat-1'));
+    expect(result).toEqual({ id: 'strat-1', enabled: false });
+  });
+
+  it('should throw if strategy not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new ToggleStrategyCommand('user-1', 'non-existent')),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api-server/src/strategies/commands/update-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/update-strategy.handler.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { UpdateStrategyHandler } from './update-strategy.handler';
+import { UpdateStrategyCommand } from './update-strategy.command';
+
+const mockPrisma = {
+  strategy: { findFirst: vi.fn(), update: vi.fn() },
+  exchangeKey: { findFirst: vi.fn() },
+};
+
+describe('UpdateStrategyHandler', () => {
+  let handler: UpdateStrategyHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new UpdateStrategyHandler(mockPrisma as never);
+  });
+
+  it('should update strategy fields', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
+    mockPrisma.strategy.update.mockResolvedValue({ id: 'strat-1', name: 'Updated' });
+
+    const result = await handler.execute(
+      new UpdateStrategyCommand('user-1', 'strat-1', { name: 'Updated' } as never),
+    );
+
+    expect(result).toEqual({ id: 'strat-1', name: 'Updated' });
+  });
+
+  it('should throw if strategy not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new UpdateStrategyCommand('user-1', 'non-existent', {} as never)),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api-server/src/strategies/queries/get-strategies.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategies.handler.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetStrategiesHandler } from './get-strategies.handler';
+import { GetStrategiesQuery } from './get-strategies.query';
+
+const mockPrisma = { strategy: { findMany: vi.fn() } };
+
+describe('GetStrategiesHandler', () => {
+  let handler: GetStrategiesHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetStrategiesHandler(mockPrisma as never);
+  });
+
+  it('should return all strategies for user', async () => {
+    const strategies = [
+      { id: 'strat-1', name: 'RSI', type: 'rsi' },
+      { id: 'strat-2', name: 'MACD', type: 'macd' },
+    ];
+    mockPrisma.strategy.findMany.mockResolvedValue(strategies);
+
+    const result = await handler.execute(new GetStrategiesQuery('user-1'));
+    expect(result).toEqual(strategies);
+    expect(mockPrisma.strategy.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'user-1' } }),
+    );
+  });
+});

--- a/apps/api-server/src/strategies/queries/get-strategy-logs.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy-logs.handler.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { GetStrategyLogsHandler } from './get-strategy-logs.handler';
+import { GetStrategyLogsQuery } from './get-strategy-logs.query';
+
+const mockPrisma = {
+  strategy: { findFirst: vi.fn() },
+  strategyLog: { findMany: vi.fn() },
+};
+
+describe('GetStrategyLogsHandler', () => {
+  let handler: GetStrategyLogsHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetStrategyLogsHandler(mockPrisma as never);
+  });
+
+  it('should return logs with pagination', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
+    mockPrisma.strategyLog.findMany.mockResolvedValue([
+      { id: 'log-1', action: 'evaluate', createdAt: new Date('2025-01-01') },
+    ]);
+
+    const result = await handler.execute(new GetStrategyLogsQuery('user-1', 'strat-1'));
+    expect(result.items).toHaveLength(1);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('should throw if strategy not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new GetStrategyLogsQuery('user-1', 'non-existent')),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('should apply action and signal filters', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
+    mockPrisma.strategyLog.findMany.mockResolvedValue([]);
+
+    await handler.execute(
+      new GetStrategyLogsQuery('user-1', 'strat-1', undefined, 20, 'signal_generated', 'buy'),
+    );
+
+    const where = mockPrisma.strategyLog.findMany.mock.calls[0][0].where;
+    expect(where.action).toBe('signal_generated');
+    expect(where.signal).toBe('buy');
+  });
+});

--- a/apps/api-server/src/strategies/queries/get-strategy-performance.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy-performance.handler.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { GetStrategyPerformanceHandler } from './get-strategy-performance.handler';
+import { GetStrategyPerformanceQuery } from './get-strategy-performance.query';
+
+const mockPrisma = {
+  strategy: { findFirst: vi.fn() },
+  strategyLog: { findMany: vi.fn() },
+  order: { findMany: vi.fn() },
+};
+
+describe('GetStrategyPerformanceHandler', () => {
+  let handler: GetStrategyPerformanceHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetStrategyPerformanceHandler(mockPrisma as never);
+  });
+
+  it('should throw if strategy not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new GetStrategyPerformanceQuery('user-1', 'non-existent')),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('should return zero metrics when no logs exist', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', config: {} });
+    mockPrisma.strategyLog.findMany.mockResolvedValue([]);
+
+    const result = await handler.execute(new GetStrategyPerformanceQuery('user-1', 'strat-1'));
+    expect(result.totalTrades).toBe(0);
+    expect(result.winRate).toBe(0);
+    expect(result.realizedPnl).toBe(0);
+  });
+
+  it('should calculate performance from order logs', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', config: {} });
+    mockPrisma.strategyLog.findMany.mockResolvedValue([
+      { action: 'order_placed', details: { orderId: 'o1' }, createdAt: new Date('2025-01-01') },
+      { action: 'order_placed', details: { orderId: 'o2' }, createdAt: new Date('2025-01-02') },
+    ]);
+    mockPrisma.order.findMany.mockResolvedValue([
+      {
+        id: 'o1',
+        side: 'buy',
+        filledPrice: '100',
+        filledQuantity: '1',
+        fee: '0.1',
+        status: 'filled',
+        createdAt: new Date('2025-01-01'),
+      },
+      {
+        id: 'o2',
+        side: 'sell',
+        filledPrice: '110',
+        filledQuantity: '1',
+        fee: '0.1',
+        status: 'filled',
+        createdAt: new Date('2025-01-02'),
+      },
+    ]);
+
+    const result = await handler.execute(new GetStrategyPerformanceQuery('user-1', 'strat-1'));
+    expect(result.totalTrades).toBeGreaterThan(0);
+    expect(result.realizedPnl).toBeGreaterThan(0);
+  });
+});

--- a/apps/api-server/src/strategies/queries/get-strategy-signals.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy-signals.handler.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { GetStrategySignalsHandler } from './get-strategy-signals.handler';
+import { GetStrategySignalsQuery } from './get-strategy-signals.query';
+
+const mockPrisma = {
+  strategy: { findFirst: vi.fn() },
+  strategyLog: { findMany: vi.fn() },
+};
+
+describe('GetStrategySignalsHandler', () => {
+  let handler: GetStrategySignalsHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetStrategySignalsHandler(mockPrisma as never);
+  });
+
+  it('should return mapped signals', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
+    mockPrisma.strategyLog.findMany.mockResolvedValue([
+      {
+        signal: 'buy',
+        action: 'signal_generated',
+        details: { price: 50000000 },
+        createdAt: new Date('2025-01-01'),
+      },
+    ]);
+
+    const result = await handler.execute(new GetStrategySignalsQuery('user-1', 'strat-1'));
+    expect(result).toHaveLength(1);
+    expect(result[0].signal).toBe('buy');
+    expect(result[0].price).toBe(50000000);
+  });
+
+  it('should throw if strategy not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(
+      handler.execute(new GetStrategySignalsQuery('user-1', 'non-existent')),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api-server/src/strategies/queries/get-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy.handler.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundException } from '@nestjs/common';
+import { GetStrategyHandler } from './get-strategy.handler';
+import { GetStrategyQuery } from './get-strategy.query';
+
+const mockPrisma = { strategy: { findFirst: vi.fn() } };
+
+describe('GetStrategyHandler', () => {
+  let handler: GetStrategyHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new GetStrategyHandler(mockPrisma as never);
+  });
+
+  it('should return a strategy', async () => {
+    const strategy = { id: 'strat-1', name: 'RSI', userId: 'user-1' };
+    mockPrisma.strategy.findFirst.mockResolvedValue(strategy);
+
+    const result = await handler.execute(new GetStrategyQuery('user-1', 'strat-1'));
+    expect(result).toEqual(strategy);
+  });
+
+  it('should throw if not found', async () => {
+    mockPrisma.strategy.findFirst.mockResolvedValue(null);
+
+    await expect(handler.execute(new GetStrategyQuery('user-1', 'non-existent'))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- api-server의 전체 CQRS Command/Query 핸들러 단위 테스트 추가
- Prisma Client 모킹, exchange adapter 모킹 (class mock)
- 총 45개 테스트 전부 통과

## 테스트 커버리지

### Command Handlers (19 tests)
| 핸들러 | 테스트 수 | 주요 시나리오 |
|--------|-----------|-------------|
| CreateOrderHandler | 5 | paper/real 모드, validation, comma 제거, exchangeKey 검증 |
| CancelOrderHandler | 3 | pending 취소, not found, already filled |
| CreateStrategyHandler | 3 | paper/real 모드, exchangeKey 검증 |
| UpdateStrategyHandler | 2 | 필드 수정, not found |
| DeleteStrategyHandler | 2 | 삭제, not found |
| ToggleStrategyHandler | 3 | on→off, off→on, not found |
| CreateExchangeKeyHandler | 3 | 암호화 upsert, API 검증 실패, master key 누락 |
| DeleteExchangeKeyHandler | 2 | 삭제, not found |
| UpdateNotificationSettingHandler | 1 | upsert |

### Query Handlers (26 tests)
| 핸들러 | 테스트 수 | 주요 시나리오 |
|--------|-----------|-------------|
| GetOrdersHandler | 3 | 페이지네이션, 필터, nextCursor |
| GetOrderHandler | 2 | 조회, not found |
| GetExchangeKeysHandler | 1 | sensitive data 제외 |
| GetNotificationSettingsHandler | 2 | 기존 설정, 기본값 |
| GetStrategiesHandler | 1 | userId 필터 |
| GetStrategyHandler | 2 | 조회, not found |
| GetStrategyLogsHandler | 3 | 페이지네이션, 필터, 소유권 검증 |
| GetStrategySignalsHandler | 2 | 시그널 매핑, not found |
| GetStrategyPerformanceHandler | 3 | zero metrics, order 기반 계산, not found |
| GetPortfolioSummaryHandler | 2 | 서비스 위임, mode 전달 |

## Closes #49

## Test plan
- [x] `pnpm --filter api-server test:unit` — 45 tests passed
- [x] `pnpm turbo run test:unit build` — 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)