### PR TITLE
test: 인증/토큰/사가 테스트 추가 및 전체 테스트 한글화 (#50)

### DIFF
--- a/apps/api-server/src/auth/auth.service.test.ts
+++ b/apps/api-server/src/auth/auth.service.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { AuthService } from './auth.service';
+
+vi.mock('bcrypt', () => ({
+  hash: vi.fn().mockResolvedValue('$hashed$'),
+  compare: vi.fn(),
+}));
+
+const mockPrisma = {
+  user: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
+  account: { findUnique: vi.fn(), create: vi.fn() },
+  $transaction: vi.fn((fn: (tx: unknown) => unknown) => fn(mockPrisma)),
+};
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AuthService(mockPrisma as never);
+  });
+
+  describe('회원가입 (signup)', () => {
+    it('새 사용자를 생성해야 한다', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      mockPrisma.user.create.mockResolvedValue({ id: 'u1', email: 'test@test.com' });
+
+      const result = await service.signup({ email: 'test@test.com', password: 'pass123' } as never);
+      expect(result.id).toBe('u1');
+      expect(bcrypt.hash).toHaveBeenCalledWith('pass123', 10);
+    });
+
+    it('이미 비밀번호로 등록된 이메일이면 ConflictException을 던져야 한다', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1', password: '$existing$' });
+
+      await expect(
+        service.signup({ email: 'test@test.com', password: 'pass' } as never),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('기존 OAuth 사용자에 비밀번호를 업데이트해야 한다', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1', password: null, nickname: 'old' });
+      mockPrisma.user.update.mockResolvedValue({ id: 'u1', password: '$hashed$' });
+
+      const result = await service.signup({ email: 'test@test.com', password: 'pass' } as never);
+      expect(mockPrisma.user.update).toHaveBeenCalled();
+      expect(result.id).toBe('u1');
+    });
+  });
+
+  describe('로컬 사용자 검증 (validateLocalUser)', () => {
+    it('유효한 자격증명이면 사용자를 반환해야 한다', async () => {
+      const user = { id: 'u1', email: 'test@test.com', password: '$hashed$' };
+      mockPrisma.user.findUnique.mockResolvedValue(user);
+      (bcrypt.compare as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+      const result = await service.validateLocalUser('test@test.com', 'pass');
+      expect(result).toEqual(user);
+    });
+
+    it('존재하지 않는 사용자이면 예외를 던져야 한다', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.validateLocalUser('x@x.com', 'pass')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('비밀번호가 틀리면 예외를 던져야 한다', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1', password: '$hashed$' });
+      (bcrypt.compare as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      await expect(service.validateLocalUser('test@test.com', 'wrong')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('OAuth 사용자 검증 (validateOAuthUser)', () => {
+    it('계정이 존재하면 기존 사용자를 반환해야 한다', async () => {
+      const user = { id: 'u1', email: 'test@test.com' };
+      mockPrisma.account.findUnique.mockResolvedValue({ user });
+
+      const result = await service.validateOAuthUser('google', 'gid-1', {
+        email: 'test@test.com',
+      });
+      expect(result).toEqual(user);
+    });
+
+    it('이메일로 기존 사용자에 계정을 연결해야 한다', async () => {
+      mockPrisma.account.findUnique.mockResolvedValue(null);
+      const user = { id: 'u1', email: 'test@test.com' };
+      mockPrisma.user.findUnique.mockResolvedValue(user);
+      mockPrisma.account.create.mockResolvedValue({});
+
+      const result = await service.validateOAuthUser('google', 'gid-1', {
+        email: 'test@test.com',
+      });
+      expect(result).toEqual(user);
+      expect(mockPrisma.account.create).toHaveBeenCalled();
+    });
+
+    it('일치하는 계정이 없으면 새 사용자와 계정을 생성해야 한다', async () => {
+      mockPrisma.account.findUnique.mockResolvedValue(null);
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      const newUser = { id: 'u2', email: 'new@test.com' };
+      mockPrisma.user.create.mockResolvedValue(newUser);
+      mockPrisma.account.create.mockResolvedValue({});
+      mockPrisma.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+        fn(mockPrisma),
+      );
+
+      const result = await service.validateOAuthUser('kakao', 'kid-1', {
+        email: 'new@test.com',
+        nickname: 'newbie',
+      });
+      expect(result).toEqual(newUser);
+    });
+  });
+
+  describe('사용자 조회 (getUserById)', () => {
+    it('사용자를 반환해야 한다', async () => {
+      const user = { id: 'u1' };
+      mockPrisma.user.findUnique.mockResolvedValue(user);
+      expect(await service.getUserById('u1')).toEqual(user);
+    });
+
+    it('찾을 수 없으면 null을 반환해야 한다', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      expect(await service.getUserById('x')).toBeNull();
+    });
+  });
+});

--- a/apps/api-server/src/auth/token.service.test.ts
+++ b/apps/api-server/src/auth/token.service.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UnauthorizedException } from '@nestjs/common';
+import { TokenService } from './token.service';
+
+const mockJwt = {
+  sign: vi.fn().mockReturnValue('mock-token'),
+  verify: vi.fn(),
+};
+const mockConfig = {
+  get: vi.fn((key: string, fallback?: string) => {
+    const map: Record<string, string> = {
+      JWT_REFRESH_SECRET: 'refresh-secret',
+      JWT_REFRESH_EXPIRES_IN: '7d',
+      JWT_ACCESS_EXPIRES_IN: '15m',
+      NODE_ENV: 'test',
+    };
+    return map[key] ?? fallback;
+  }),
+};
+const mockPrisma = {
+  refreshToken: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  user: { findUnique: vi.fn() },
+};
+
+describe('TokenService', () => {
+  let service: TokenService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TokenService(mockJwt as never, mockConfig as never, mockPrisma as never);
+  });
+
+  describe('토큰 쌍 발급 (issueTokenPair)', () => {
+    it('액세스 토큰과 리프레시 토큰을 발급해야 한다', async () => {
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+
+      const result = await service.issueTokenPair({ id: 'u1', email: 'test@test.com' } as never);
+      expect(result.accessToken).toBe('mock-token');
+      expect(result.refreshToken).toBe('mock-token');
+      expect(mockJwt.sign).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.refreshToken.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('리프레시 토큰 갱신 (rotateRefreshToken)', () => {
+    it('토큰을 갱신하고 새 토큰 쌍을 반환해야 한다', async () => {
+      mockJwt.verify.mockReturnValue({ sub: 'u1', jti: 'raw-token' });
+      mockPrisma.refreshToken.findUnique.mockResolvedValue({ id: 'rt1', userId: 'u1' });
+      mockPrisma.refreshToken.delete.mockResolvedValue({});
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1', email: 'test@test.com' });
+      mockPrisma.refreshToken.create.mockResolvedValue({});
+
+      const result = await service.rotateRefreshToken('old-refresh-token');
+      expect(result.accessToken).toBeDefined();
+      expect(result.refreshToken).toBeDefined();
+      expect(mockPrisma.refreshToken.delete).toHaveBeenCalled();
+    });
+
+    it('유효하지 않은 리프레시 토큰이면 예외를 던져야 한다', async () => {
+      mockJwt.verify.mockImplementation(() => {
+        throw new Error('invalid');
+      });
+
+      await expect(service.rotateRefreshToken('bad-token')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('저장된 토큰을 찾을 수 없으면 예외를 던져야 한다', async () => {
+      mockJwt.verify.mockReturnValue({ sub: 'u1', jti: 'raw' });
+      mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
+
+      await expect(service.rotateRefreshToken('token')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('토큰 검증 후 사용자를 찾을 수 없으면 예외를 던져야 한다', async () => {
+      mockJwt.verify.mockReturnValue({ sub: 'u1', jti: 'raw' });
+      mockPrisma.refreshToken.findUnique.mockResolvedValue({ id: 'rt1', userId: 'u1' });
+      mockPrisma.refreshToken.delete.mockResolvedValue({});
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.rotateRefreshToken('token')).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('리프레시 토큰 폐기 (revokeRefreshToken)', () => {
+    it('저장된 토큰을 삭제해야 한다', async () => {
+      mockJwt.verify.mockReturnValue({ jti: 'raw' });
+      mockPrisma.refreshToken.deleteMany.mockResolvedValue({});
+
+      await service.revokeRefreshToken('token');
+      expect(mockPrisma.refreshToken.deleteMany).toHaveBeenCalled();
+    });
+
+    it('유효하지 않은 토큰이어도 예외를 던지지 않아야 한다', async () => {
+      mockJwt.verify.mockImplementation(() => {
+        throw new Error('invalid');
+      });
+
+      await expect(service.revokeRefreshToken('bad')).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/api-server/src/exchange-keys/commands/create-exchange-key.handler.test.ts
+++ b/apps/api-server/src/exchange-keys/commands/create-exchange-key.handler.test.ts
@@ -36,7 +36,7 @@ describe('CreateExchangeKeyHandler', () => {
     handler = new CreateExchangeKeyHandler(mockPrisma as never, mockConfig as never);
   });
 
-  it('should create/upsert an exchange key with encrypted credentials', async () => {
+  it('암호화된 자격증명으로 거래소 키를 생성/upsert해야 한다', async () => {
     mockPrisma.exchangeKey.upsert.mockResolvedValue({
       id: 'key-1',
       exchange: 'upbit',
@@ -57,7 +57,7 @@ describe('CreateExchangeKeyHandler', () => {
     expect(upsertCall.create.secretKey).not.toBe('my-secret');
   });
 
-  it('should throw if ENCRYPTION_MASTER_KEY is not configured', async () => {
+  it('ENCRYPTION_MASTER_KEY가 설정되지 않으면 예외를 던져야 한다', async () => {
     mockConfig.getOrThrow.mockImplementation(() => {
       throw new Error('Missing ENCRYPTION_MASTER_KEY');
     });
@@ -73,7 +73,7 @@ describe('CreateExchangeKeyHandler', () => {
     ).rejects.toThrow();
   });
 
-  it('should throw BadRequestException if API validation fails', async () => {
+  it('API 검증에 실패하면 BadRequestException을 던져야 한다', async () => {
     mockGetBalances.mockRejectedValue(new Error('Invalid API key'));
 
     await expect(

--- a/apps/api-server/src/exchange-keys/commands/delete-exchange-key.handler.test.ts
+++ b/apps/api-server/src/exchange-keys/commands/delete-exchange-key.handler.test.ts
@@ -15,7 +15,7 @@ describe('DeleteExchangeKeyHandler', () => {
     handler = new DeleteExchangeKeyHandler(mockPrisma as never);
   });
 
-  it('should delete an exchange key', async () => {
+  it('거래소 키를 삭제해야 한다', async () => {
     mockPrisma.exchangeKey.findFirst.mockResolvedValue({ id: 'key-1' });
     mockPrisma.exchangeKey.delete.mockResolvedValue({ id: 'key-1' });
 
@@ -23,7 +23,7 @@ describe('DeleteExchangeKeyHandler', () => {
     expect(result).toEqual({ message: 'Deleted' });
   });
 
-  it('should throw if key not found', async () => {
+  it('키를 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.exchangeKey.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/apps/api-server/src/exchange-keys/queries/get-exchange-keys.handler.test.ts
+++ b/apps/api-server/src/exchange-keys/queries/get-exchange-keys.handler.test.ts
@@ -12,7 +12,7 @@ describe('GetExchangeKeysHandler', () => {
     handler = new GetExchangeKeysHandler(mockPrisma as never);
   });
 
-  it('should return exchange keys without sensitive data', async () => {
+  it('민감한 데이터 없이 거래소 키를 반환해야 한다', async () => {
     const keys = [{ id: 'key-1', exchange: 'upbit', createdAt: new Date() }];
     mockPrisma.exchangeKey.findMany.mockResolvedValue(keys);
 

--- a/apps/api-server/src/notifications/commands/update-notification-setting.handler.test.ts
+++ b/apps/api-server/src/notifications/commands/update-notification-setting.handler.test.ts
@@ -14,7 +14,7 @@ describe('UpdateNotificationSettingHandler', () => {
     handler = new UpdateNotificationSettingHandler(mockPrisma as never);
   });
 
-  it('should upsert notification setting', async () => {
+  it('알림 설정을 upsert해야 한다', async () => {
     const setting = { id: 'ns-1', telegramChatId: '12345', notifyOrders: true };
     mockPrisma.notificationSetting.upsert.mockResolvedValue(setting);
 

--- a/apps/api-server/src/notifications/queries/get-notification-settings.handler.test.ts
+++ b/apps/api-server/src/notifications/queries/get-notification-settings.handler.test.ts
@@ -12,7 +12,7 @@ describe('GetNotificationSettingsHandler', () => {
     handler = new GetNotificationSettingsHandler(mockPrisma as never);
   });
 
-  it('should return existing settings', async () => {
+  it('기존 설정을 반환해야 한다', async () => {
     const setting = {
       telegramChatId: '12345',
       notifyOrders: true,
@@ -25,7 +25,7 @@ describe('GetNotificationSettingsHandler', () => {
     expect(result).toEqual(setting);
   });
 
-  it('should return defaults when no settings exist', async () => {
+  it('설정이 없으면 기본값을 반환해야 한다', async () => {
     mockPrisma.notificationSetting.findUnique.mockResolvedValue(null);
 
     const result = await handler.execute(new GetNotificationSettingsQuery('user-1'));

--- a/apps/api-server/src/orders/commands/cancel-order.handler.test.ts
+++ b/apps/api-server/src/orders/commands/cancel-order.handler.test.ts
@@ -16,7 +16,7 @@ describe('CancelOrderHandler', () => {
     handler = new CancelOrderHandler(mockPrisma as never);
   });
 
-  it('should cancel a pending paper order', async () => {
+  it('대기 중인 페이퍼 주문을 취소해야 한다', async () => {
     mockPrisma.order.findFirst.mockResolvedValue({
       id: 'order-1',
       userId: 'user-1',
@@ -29,7 +29,7 @@ describe('CancelOrderHandler', () => {
     expect(result).toEqual({ id: 'order-1', status: 'cancelled' });
   });
 
-  it('should throw if order not found', async () => {
+  it('주문을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.order.findFirst.mockResolvedValue(null);
 
     await expect(handler.execute(new CancelOrderCommand('user-1', 'non-existent'))).rejects.toThrow(
@@ -37,7 +37,7 @@ describe('CancelOrderHandler', () => {
     );
   });
 
-  it('should throw if order is already filled', async () => {
+  it('이미 체결된 주문이면 예외를 던져야 한다', async () => {
     mockPrisma.order.findFirst.mockResolvedValue({
       id: 'order-1',
       userId: 'user-1',

--- a/apps/api-server/src/orders/commands/create-order.handler.test.ts
+++ b/apps/api-server/src/orders/commands/create-order.handler.test.ts
@@ -14,7 +14,7 @@ describe('CreateOrderHandler', () => {
     handler = new CreateOrderHandler(mockPrisma as never, mockOrchestrator as never);
   });
 
-  it('should create a paper market order', async () => {
+  it('페이퍼 시장가 주문을 생성해야 한다', async () => {
     mockOrchestrator.startSaga.mockResolvedValue({ id: 'order-1', status: 'pending' });
 
     const result = await handler.execute(
@@ -32,7 +32,7 @@ describe('CreateOrderHandler', () => {
     expect(result).toEqual({ id: 'order-1', status: 'pending' });
   });
 
-  it('should require exchangeKeyId for real mode', async () => {
+  it('실거래 모드에서는 exchangeKeyId가 필요하다', async () => {
     await expect(
       handler.execute(
         new CreateOrderCommand('user-1', {
@@ -47,7 +47,7 @@ describe('CreateOrderHandler', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
-  it('should validate exchange key exists for real mode', async () => {
+  it('실거래 모드에서 거래소 키가 존재하는지 검증해야 한다', async () => {
     mockPrisma.exchangeKey.findFirst.mockResolvedValue(null);
 
     await expect(
@@ -65,7 +65,7 @@ describe('CreateOrderHandler', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('should require price for limit orders', async () => {
+  it('지정가 주문에는 가격이 필요하다', async () => {
     await expect(
       handler.execute(
         new CreateOrderCommand('user-1', {
@@ -80,7 +80,7 @@ describe('CreateOrderHandler', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
-  it('should strip commas from quantity', async () => {
+  it('수량에서 쉼표를 제거해야 한다', async () => {
     mockOrchestrator.startSaga.mockResolvedValue({ id: 'order-1' });
 
     await handler.execute(

--- a/apps/api-server/src/orders/queries/get-order.handler.test.ts
+++ b/apps/api-server/src/orders/queries/get-order.handler.test.ts
@@ -13,7 +13,7 @@ describe('GetOrderHandler', () => {
     handler = new GetOrderHandler(mockPrisma as never);
   });
 
-  it('should return an order', async () => {
+  it('주문을 반환해야 한다', async () => {
     const order = { id: 'order-1', userId: 'user-1', symbol: 'KRW-BTC' };
     mockPrisma.order.findFirst.mockResolvedValue(order);
 
@@ -21,7 +21,7 @@ describe('GetOrderHandler', () => {
     expect(result).toEqual(order);
   });
 
-  it('should throw NotFoundException if not found', async () => {
+  it('찾을 수 없으면 NotFoundException을 던져야 한다', async () => {
     mockPrisma.order.findFirst.mockResolvedValue(null);
 
     await expect(handler.execute(new GetOrderQuery('user-1', 'non-existent'))).rejects.toThrow(

--- a/apps/api-server/src/orders/queries/get-orders.handler.test.ts
+++ b/apps/api-server/src/orders/queries/get-orders.handler.test.ts
@@ -12,7 +12,7 @@ describe('GetOrdersHandler', () => {
     handler = new GetOrdersHandler(mockPrisma as never);
   });
 
-  it('should return orders with pagination', async () => {
+  it('페이지네이션으로 주문 목록을 반환해야 한다', async () => {
     const orders = [
       { id: '1', createdAt: new Date('2025-01-02') },
       { id: '2', createdAt: new Date('2025-01-01') },
@@ -24,7 +24,7 @@ describe('GetOrdersHandler', () => {
     expect(result.nextCursor).toBeNull();
   });
 
-  it('should return nextCursor when hasMore', async () => {
+  it('더 많은 데이터가 있으면 nextCursor를 반환해야 한다', async () => {
     // Return limit + 1 items to indicate hasMore
     const orders = Array.from({ length: 21 }, (_, i) => ({
       id: `order-${i}`,
@@ -37,7 +37,7 @@ describe('GetOrdersHandler', () => {
     expect(result.nextCursor).toBeDefined();
   });
 
-  it('should apply filters', async () => {
+  it('필터를 적용해야 한다', async () => {
     mockPrisma.order.findMany.mockResolvedValue([]);
 
     await handler.execute(

--- a/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.test.ts
+++ b/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.test.ts
@@ -12,7 +12,7 @@ describe('GetPortfolioSummaryHandler', () => {
     handler = new GetPortfolioSummaryHandler(mockPortfolioService as never);
   });
 
-  it('should delegate to portfolioService.getSummary', async () => {
+  it('portfolioService.getSummary에 위임해야 한다', async () => {
     const summary = { totalValue: 1000, assets: [] };
     mockPortfolioService.getSummary.mockResolvedValue(summary);
 
@@ -21,7 +21,7 @@ describe('GetPortfolioSummaryHandler', () => {
     expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', 'paper');
   });
 
-  it('should pass mode "all" when not specified', async () => {
+  it('모드가 지정되지 않으면 undefined를 전달해야 한다', async () => {
     mockPortfolioService.getSummary.mockResolvedValue({});
 
     await handler.execute(new GetPortfolioSummaryQuery('user-1'));

--- a/apps/api-server/src/saga/saga-step-runner.test.ts
+++ b/apps/api-server/src/saga/saga-step-runner.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SagaStepRunner } from './saga-step-runner';
+import type { SagaStep } from './saga-step.interface';
+
+const mockPrisma = {
+  sagaExecution: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+};
+
+interface TestContext {
+  value: number;
+}
+
+function createStep(
+  name: string,
+  executeFn: (ctx: TestContext) => TestContext,
+  compensateFn: (ctx: TestContext) => void = () => {},
+): SagaStep<TestContext> {
+  return {
+    name,
+    execute: vi.fn(async (ctx) => executeFn(ctx)),
+    compensate: vi.fn(async (ctx) => compensateFn(ctx)),
+  };
+}
+
+const defaultOptions = {
+  sagaType: 'test',
+  correlationId: 'corr-1',
+  userId: 'user-1',
+  timeoutMs: 60000,
+};
+
+describe('SagaStepRunner', () => {
+  let runner: SagaStepRunner<TestContext>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.sagaExecution.findUnique.mockResolvedValue(null);
+    mockPrisma.sagaExecution.create.mockResolvedValue({ id: 'saga-1' });
+    mockPrisma.sagaExecution.update.mockResolvedValue({});
+    runner = new SagaStepRunner<TestContext>(mockPrisma as never);
+  });
+
+  it('모든 스텝을 순서대로 실행해야 한다', async () => {
+    const step1 = createStep('step1', (ctx) => ({ value: ctx.value + 1 }));
+    const step2 = createStep('step2', (ctx) => ({ value: ctx.value * 2 }));
+
+    runner.addStep(step1).addStep(step2);
+
+    const result = await runner.run({ value: 1 }, defaultOptions);
+    expect(result.value).toBe(4); // (1+1)*2
+    expect(step1.execute).toHaveBeenCalled();
+    expect(step2.execute).toHaveBeenCalled();
+  });
+
+  it('실패 시 역순으로 보상해야 한다', async () => {
+    const compensateOrder: string[] = [];
+    const step1 = createStep(
+      'step1',
+      (ctx) => ({ value: ctx.value + 1 }),
+      () => compensateOrder.push('step1'),
+    );
+    const step2 = createStep(
+      'step2',
+      (ctx) => ({ value: ctx.value + 1 }),
+      () => compensateOrder.push('step2'),
+    );
+    const step3 = createStep('step3', () => {
+      throw new Error('step3 failed');
+    });
+
+    runner.addStep(step1).addStep(step2).addStep(step3);
+
+    await expect(runner.run({ value: 0 }, defaultOptions)).rejects.toThrow('step3 failed');
+
+    // Compensation should be in reverse: step2, step1
+    expect(compensateOrder).toEqual(['step2', 'step1']);
+  });
+
+  it('성공 시 사가를 completed로 표시해야 한다', async () => {
+    runner.addStep(createStep('step1', (ctx) => ctx));
+    await runner.run({ value: 0 }, defaultOptions);
+
+    const lastUpdate = mockPrisma.sagaExecution.update.mock.calls.at(-1)?.[0];
+    expect(lastUpdate?.data.status).toBe('completed');
+  });
+
+  it('보상 후 사가를 failed로 표시해야 한다', async () => {
+    runner.addStep(
+      createStep('fail', () => {
+        throw new Error('fail');
+      }),
+    );
+
+    await expect(runner.run({ value: 0 }, defaultOptions)).rejects.toThrow();
+
+    const failedUpdate = mockPrisma.sagaExecution.update.mock.calls.find(
+      (call: unknown[]) => (call[0] as { data: { status: string } }).data.status === 'failed',
+    );
+    expect(failedUpdate).toBeDefined();
+  });
+
+  it('이미 완료된 사가이면 건너뛰어야 한다', async () => {
+    mockPrisma.sagaExecution.findUnique.mockResolvedValue({
+      status: 'completed',
+      context: { value: 42 },
+    });
+
+    const step = createStep('step1', (ctx) => ctx);
+    runner.addStep(step);
+
+    const result = await runner.run({ value: 0 }, defaultOptions);
+    expect(result.value).toBe(42);
+    expect(step.execute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api-server/src/strategies/commands/create-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/create-strategy.handler.test.ts
@@ -16,7 +16,7 @@ describe('CreateStrategyHandler', () => {
     handler = new CreateStrategyHandler(mockPrisma as never);
   });
 
-  it('should create a paper strategy', async () => {
+  it('페이퍼 전략을 생성해야 한다', async () => {
     const created = { id: 'strat-1', name: 'RSI Test', type: 'rsi' };
     mockPrisma.strategy.create.mockResolvedValue(created);
 
@@ -36,7 +36,7 @@ describe('CreateStrategyHandler', () => {
     expect(mockPrisma.strategy.create).toHaveBeenCalled();
   });
 
-  it('should require exchangeKeyId for real tradingMode', async () => {
+  it('실거래 모드에서는 exchangeKeyId가 필요하다', async () => {
     await expect(
       handler.execute(
         new CreateStrategyCommand('user-1', {
@@ -52,7 +52,7 @@ describe('CreateStrategyHandler', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
-  it('should validate exchange key exists for real mode', async () => {
+  it('실거래 모드에서 거래소 키가 존재하는지 검증해야 한다', async () => {
     mockPrisma.exchangeKey.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/apps/api-server/src/strategies/commands/delete-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/delete-strategy.handler.test.ts
@@ -15,7 +15,7 @@ describe('DeleteStrategyHandler', () => {
     handler = new DeleteStrategyHandler(mockPrisma as never);
   });
 
-  it('should delete a strategy', async () => {
+  it('전략을 삭제해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
     mockPrisma.strategy.delete.mockResolvedValue({ id: 'strat-1' });
 
@@ -23,7 +23,7 @@ describe('DeleteStrategyHandler', () => {
     expect(result).toEqual({ id: 'strat-1', deleted: true });
   });
 
-  it('should throw if strategy not found', async () => {
+  it('전략을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/apps/api-server/src/strategies/commands/toggle-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/toggle-strategy.handler.test.ts
@@ -15,7 +15,7 @@ describe('ToggleStrategyHandler', () => {
     handler = new ToggleStrategyHandler(mockPrisma as never);
   });
 
-  it('should toggle enabled from false to true', async () => {
+  it('enabled를 false에서 true로 토글해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', enabled: false });
     mockPrisma.strategy.update.mockResolvedValue({ id: 'strat-1', enabled: true });
 
@@ -26,7 +26,7 @@ describe('ToggleStrategyHandler', () => {
     );
   });
 
-  it('should toggle enabled from true to false', async () => {
+  it('enabled를 true에서 false로 토글해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', enabled: true });
     mockPrisma.strategy.update.mockResolvedValue({ id: 'strat-1', enabled: false });
 
@@ -34,7 +34,7 @@ describe('ToggleStrategyHandler', () => {
     expect(result).toEqual({ id: 'strat-1', enabled: false });
   });
 
-  it('should throw if strategy not found', async () => {
+  it('전략을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/apps/api-server/src/strategies/commands/update-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/update-strategy.handler.test.ts
@@ -16,7 +16,7 @@ describe('UpdateStrategyHandler', () => {
     handler = new UpdateStrategyHandler(mockPrisma as never);
   });
 
-  it('should update strategy fields', async () => {
+  it('전략 필드를 업데이트해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
     mockPrisma.strategy.update.mockResolvedValue({ id: 'strat-1', name: 'Updated' });
 
@@ -27,7 +27,7 @@ describe('UpdateStrategyHandler', () => {
     expect(result).toEqual({ id: 'strat-1', name: 'Updated' });
   });
 
-  it('should throw if strategy not found', async () => {
+  it('전략을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/apps/api-server/src/strategies/queries/get-strategies.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategies.handler.test.ts
@@ -12,7 +12,7 @@ describe('GetStrategiesHandler', () => {
     handler = new GetStrategiesHandler(mockPrisma as never);
   });
 
-  it('should return all strategies for user', async () => {
+  it('사용자의 모든 전략을 반환해야 한다', async () => {
     const strategies = [
       { id: 'strat-1', name: 'RSI', type: 'rsi' },
       { id: 'strat-2', name: 'MACD', type: 'macd' },

--- a/apps/api-server/src/strategies/queries/get-strategy-logs.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy-logs.handler.test.ts
@@ -16,7 +16,7 @@ describe('GetStrategyLogsHandler', () => {
     handler = new GetStrategyLogsHandler(mockPrisma as never);
   });
 
-  it('should return logs with pagination', async () => {
+  it('페이지네이션으로 로그를 반환해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
     mockPrisma.strategyLog.findMany.mockResolvedValue([
       { id: 'log-1', action: 'evaluate', createdAt: new Date('2025-01-01') },
@@ -27,7 +27,7 @@ describe('GetStrategyLogsHandler', () => {
     expect(result.nextCursor).toBeNull();
   });
 
-  it('should throw if strategy not found', async () => {
+  it('전략을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(
@@ -35,7 +35,7 @@ describe('GetStrategyLogsHandler', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('should apply action and signal filters', async () => {
+  it('action과 signal 필터를 적용해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
     mockPrisma.strategyLog.findMany.mockResolvedValue([]);
 

--- a/apps/api-server/src/strategies/queries/get-strategy-performance.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy-performance.handler.test.ts
@@ -17,7 +17,7 @@ describe('GetStrategyPerformanceHandler', () => {
     handler = new GetStrategyPerformanceHandler(mockPrisma as never);
   });
 
-  it('should throw if strategy not found', async () => {
+  it('전략을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(
@@ -25,7 +25,7 @@ describe('GetStrategyPerformanceHandler', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('should return zero metrics when no logs exist', async () => {
+  it('로그가 없으면 0 메트릭을 반환해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', config: {} });
     mockPrisma.strategyLog.findMany.mockResolvedValue([]);
 
@@ -35,7 +35,7 @@ describe('GetStrategyPerformanceHandler', () => {
     expect(result.realizedPnl).toBe(0);
   });
 
-  it('should calculate performance from order logs', async () => {
+  it('주문 로그로부터 성과를 계산해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1', config: {} });
     mockPrisma.strategyLog.findMany.mockResolvedValue([
       { action: 'order_placed', details: { orderId: 'o1' }, createdAt: new Date('2025-01-01') },

--- a/apps/api-server/src/strategies/queries/get-strategy-signals.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy-signals.handler.test.ts
@@ -16,7 +16,7 @@ describe('GetStrategySignalsHandler', () => {
     handler = new GetStrategySignalsHandler(mockPrisma as never);
   });
 
-  it('should return mapped signals', async () => {
+  it('매핑된 시그널을 반환해야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue({ id: 'strat-1' });
     mockPrisma.strategyLog.findMany.mockResolvedValue([
       {
@@ -33,7 +33,7 @@ describe('GetStrategySignalsHandler', () => {
     expect(result[0].price).toBe(50000000);
   });
 
-  it('should throw if strategy not found', async () => {
+  it('전략을 찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/apps/api-server/src/strategies/queries/get-strategy.handler.test.ts
+++ b/apps/api-server/src/strategies/queries/get-strategy.handler.test.ts
@@ -13,7 +13,7 @@ describe('GetStrategyHandler', () => {
     handler = new GetStrategyHandler(mockPrisma as never);
   });
 
-  it('should return a strategy', async () => {
+  it('전략을 반환해야 한다', async () => {
     const strategy = { id: 'strat-1', name: 'RSI', userId: 'user-1' };
     mockPrisma.strategy.findFirst.mockResolvedValue(strategy);
 
@@ -21,7 +21,7 @@ describe('GetStrategyHandler', () => {
     expect(result).toEqual(strategy);
   });
 
-  it('should throw if not found', async () => {
+  it('찾을 수 없으면 예외를 던져야 한다', async () => {
     mockPrisma.strategy.findFirst.mockResolvedValue(null);
 
     await expect(handler.execute(new GetStrategyQuery('user-1', 'non-existent'))).rejects.toThrow(

--- a/apps/api-server/vitest.config.ts
+++ b/apps/api-server/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    reporters: ['verbose'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    reporters: ['verbose'],
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./src/test-setup.ts'],

--- a/apps/worker-service/src/strategies/indicators/bollinger.strategy.test.ts
+++ b/apps/worker-service/src/strategies/indicators/bollinger.strategy.test.ts
@@ -23,13 +23,13 @@ function generateNeutralPrices(length = 25): number[] {
 }
 
 describe('BollingerStrategy', () => {
-  it('should return hold when not enough data', () => {
+  it('데이터가 부족하면 hold를 반환해야 한다', () => {
     const result = strategy.evaluate([100, 101, 102], { period: 20 });
     expect(result.signal).toBe('hold');
     expect(result.reason).toContain('Not enough data');
   });
 
-  it('should return buy when price < lower band', () => {
+  it('가격이 하단 밴드 미만이면 buy를 반환해야 한다', () => {
     const prices = generateBuySignalPrices(25);
     const result = strategy.evaluate(prices, { period: 20, stdDev: 2 });
     expect(result.signal).toBe('buy');
@@ -41,7 +41,7 @@ describe('BollingerStrategy', () => {
     expect(result.indicatorValues).toHaveProperty('price');
   });
 
-  it('should return sell when price > upper band', () => {
+  it('가격이 상단 밴드 초과이면 sell를 반환해야 한다', () => {
     const prices = generateSellSignalPrices(25);
     const result = strategy.evaluate(prices, { period: 20, stdDev: 2 });
     expect(result.signal).toBe('sell');
@@ -49,25 +49,25 @@ describe('BollingerStrategy', () => {
     expect(result.reason).toContain('Upper Band');
   });
 
-  it('should return hold when price within bands', () => {
+  it('가격이 밴드 내에 있으면 hold를 반환해야 한다', () => {
     const prices = generateNeutralPrices(25);
     const result = strategy.evaluate(prices, { period: 20, stdDev: 2 });
     expect(result.signal).toBe('hold');
     expect(result.reason).toContain('within bands');
   });
 
-  it('should use default config', () => {
+  it('기본 설정을 사용해야 한다', () => {
     const prices = generateNeutralPrices(25);
     const result = strategy.evaluate(prices, {});
     // Defaults: period=20, stdDev=2
     expect(result.signal).toBeDefined();
   });
 
-  it('should have type "bollinger"', () => {
+  it('타입이 "bollinger"여야 한다', () => {
     expect(strategy.type).toBe('bollinger');
   });
 
-  it('should handle narrow bands with small stdDev', () => {
+  it('작은 stdDev로 좁은 밴드를 처리해야 한다', () => {
     // With stdDev=1, bands are narrower → more likely to trigger signals
     const prices = generateNeutralPrices(25);
     prices.push(105); // Moderate price that might exceed narrow bands

--- a/apps/worker-service/src/strategies/indicators/macd.strategy.test.ts
+++ b/apps/worker-service/src/strategies/indicators/macd.strategy.test.ts
@@ -36,7 +36,7 @@ function generateFlatPrices(length = 50): number[] {
 }
 
 describe('MacdStrategy', () => {
-  it('should return hold when not enough data', () => {
+  it('데이터가 부족하면 hold를 반환해야 한다', () => {
     const result = strategy.evaluate([100, 101], {
       fastPeriod: 12,
       slowPeriod: 26,
@@ -46,7 +46,7 @@ describe('MacdStrategy', () => {
     expect(result.reason).toContain('Not enough data');
   });
 
-  it('should detect bullish crossover (buy signal)', () => {
+  it('골든크로스(매수 시그널)를 감지해야 한다', () => {
     const prices = generateBullishCrossoverPrices(60);
     const result = strategy.evaluate(prices, { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 });
     // We expect buy or hold depending on exact crossover timing
@@ -57,7 +57,7 @@ describe('MacdStrategy', () => {
     }
   });
 
-  it('should detect bearish crossover (sell signal)', () => {
+  it('데드크로스(매도 시그널)를 감지해야 한다', () => {
     const prices = generateBearishCrossoverPrices(60);
     const result = strategy.evaluate(prices, { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 });
     expect(['sell', 'hold']).toContain(result.signal);
@@ -67,7 +67,7 @@ describe('MacdStrategy', () => {
     }
   });
 
-  it('should include MACD values in result', () => {
+  it('결과에 MACD 값이 포함되어야 한다', () => {
     const prices = generateFlatPrices(60);
     const result = strategy.evaluate(prices, { fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 });
     // Regardless of signal, should have valid indicator values
@@ -75,7 +75,7 @@ describe('MacdStrategy', () => {
     expect(result.reason).toBeDefined();
   });
 
-  it('should include indicator values', () => {
+  it('지표 값이 포함되어야 한다', () => {
     const prices = generateFlatPrices(60);
     const result = strategy.evaluate(prices, {});
     if (Object.keys(result.indicatorValues).length > 0) {
@@ -85,13 +85,13 @@ describe('MacdStrategy', () => {
     }
   });
 
-  it('should use default config', () => {
+  it('기본 설정을 사용해야 한다', () => {
     const prices = generateFlatPrices(60);
     const result = strategy.evaluate(prices, {});
     expect(result.signal).toBeDefined();
   });
 
-  it('should have type "macd"', () => {
+  it('타입이 "macd"여야 한다', () => {
     expect(strategy.type).toBe('macd');
   });
 });

--- a/apps/worker-service/src/strategies/indicators/rsi.strategy.test.ts
+++ b/apps/worker-service/src/strategies/indicators/rsi.strategy.test.ts
@@ -19,14 +19,14 @@ function generateFlatPrices(length: number, base = 100): number[] {
 }
 
 describe('RsiStrategy', () => {
-  it('should return hold when not enough data', () => {
+  it('데이터가 부족하면 hold를 반환해야 한다', () => {
     const result = strategy.evaluate([100, 101, 102], { period: 14 });
     expect(result.signal).toBe('hold');
     expect(result.confidence).toBe(0);
     expect(result.reason).toContain('Not enough data');
   });
 
-  it('should return buy when RSI <= oversold (30)', () => {
+  it('RSI가 과매도(30) 이하이면 buy를 반환해야 한다', () => {
     // Strongly decreasing prices → low RSI
     const prices = generateDecreasingPrices(30);
     const result = strategy.evaluate(prices, { period: 14, overbought: 70, oversold: 30 });
@@ -36,7 +36,7 @@ describe('RsiStrategy', () => {
     expect(Number(result.indicatorValues.rsi)).toBeLessThanOrEqual(30);
   });
 
-  it('should return sell when RSI >= overbought (70)', () => {
+  it('RSI가 과매수(70) 이상이면 sell를 반환해야 한다', () => {
     // Strongly increasing prices → high RSI
     const prices = generateIncreasingPrices(30);
     const result = strategy.evaluate(prices, { period: 14, overbought: 70, oversold: 30 });
@@ -45,14 +45,14 @@ describe('RsiStrategy', () => {
     expect(Number(result.indicatorValues.rsi)).toBeGreaterThanOrEqual(70);
   });
 
-  it('should return hold when RSI is in neutral zone', () => {
+  it('RSI가 중립 구간이면 hold를 반환해야 한다', () => {
     const prices = generateFlatPrices(30);
     const result = strategy.evaluate(prices, { period: 14, overbought: 70, oversold: 30 });
     expect(result.signal).toBe('hold');
     expect(result.reason).toContain('neutral');
   });
 
-  it('should use default config when not provided', () => {
+  it('설정이 없으면 기본값을 사용해야 한다', () => {
     const prices = generateFlatPrices(30);
     const result = strategy.evaluate(prices, {});
     // Should use defaults: period=14, overbought=70, oversold=30
@@ -60,7 +60,7 @@ describe('RsiStrategy', () => {
     expect(result.indicatorValues.rsi).toBeDefined();
   });
 
-  it('should respect custom thresholds', () => {
+  it('사용자 정의 임계값을 적용해야 한다', () => {
     const prices = generateIncreasingPrices(30);
     // Default overbought=70 should trigger sell on strong uptrend
     const resultDefault = strategy.evaluate(prices, { period: 14, overbought: 70, oversold: 30 });
@@ -73,7 +73,7 @@ describe('RsiStrategy', () => {
     expect(resultLower.confidence).toBeGreaterThanOrEqual(resultDefault.confidence);
   });
 
-  it('should have type "rsi"', () => {
+  it('타입이 "rsi"여야 한다', () => {
     expect(strategy.type).toBe('rsi');
   });
 });

--- a/apps/worker-service/src/strategies/risk/risk.service.test.ts
+++ b/apps/worker-service/src/strategies/risk/risk.service.test.ts
@@ -18,8 +18,8 @@ describe('RiskService', () => {
     service = new RiskService(mockPrisma as never);
   });
 
-  describe('checkRisk - all pass', () => {
-    it('should allow when no risk config is set', async () => {
+  describe('리스크 체크 - 모두 통과 (checkRisk - all pass)', () => {
+    it('리스크 설정이 없으면 허용해야 한다', async () => {
       const result = await service.checkRisk(
         'user-1',
         'upbit',
@@ -33,8 +33,8 @@ describe('RiskService', () => {
     });
   });
 
-  describe('stopLoss', () => {
-    it('should block buy when stop-loss triggered', async () => {
+  describe('스탑로스 (stopLoss)', () => {
+    it('스탑로스 발동 시 매수를 차단해야 한다', async () => {
       mockPrisma.order.findFirst.mockResolvedValue({
         filledPrice: '50000000', // Bought at 50M
       });
@@ -56,7 +56,7 @@ describe('RiskService', () => {
       expect(result.reason).toContain('Stop-loss triggered');
     });
 
-    it('should allow when loss is below threshold', async () => {
+    it('손실이 임계값 미만이면 허용해야 한다', async () => {
       mockPrisma.order.findFirst.mockResolvedValue({
         filledPrice: '50000000',
       });
@@ -77,7 +77,7 @@ describe('RiskService', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('should allow when no previous buy order exists', async () => {
+    it('이전 매수 주문이 없으면 허용해야 한다', async () => {
       mockPrisma.order.findFirst.mockResolvedValue(null);
 
       const result = await service.checkRisk(
@@ -95,7 +95,7 @@ describe('RiskService', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('should skip stop-loss check for sell signals', async () => {
+    it('매도 시그널에는 스탑로스 체크를 건너뛰어야 한다', async () => {
       const result = await service.checkRisk(
         'user-1',
         'upbit',
@@ -113,8 +113,8 @@ describe('RiskService', () => {
     });
   });
 
-  describe('dailyMaxLoss', () => {
-    it('should block when daily loss exceeds limit', async () => {
+  describe('일일 최대 손실 (dailyMaxLoss)', () => {
+    it('일일 손실이 한도를 초과하면 차단해야 한다', async () => {
       mockPrisma.order.findFirst.mockResolvedValue(null); // no stop-loss data
       mockPrisma.order.findMany.mockResolvedValue([
         { side: 'buy', filledPrice: '100', filledQuantity: '1', fee: '0.1' },
@@ -130,7 +130,7 @@ describe('RiskService', () => {
       expect(result.reason).toContain('Daily loss limit');
     });
 
-    it('should allow when daily loss is below limit', async () => {
+    it('일일 손실이 한도 미만이면 허용해야 한다', async () => {
       mockPrisma.order.findMany.mockResolvedValue([
         { side: 'buy', filledPrice: '100', filledQuantity: '1', fee: '0.1' },
         { side: 'sell', filledPrice: '98', filledQuantity: '1', fee: '0.1' },
@@ -144,8 +144,8 @@ describe('RiskService', () => {
     });
   });
 
-  describe('maxPositionSize', () => {
-    it('should block when position exceeds max size', async () => {
+  describe('최대 포지션 크기 (maxPositionSize)', () => {
+    it('포지션이 최대 크기를 초과하면 차단해야 한다', async () => {
       mockPrisma.order.findFirst.mockResolvedValue(null);
       mockPrisma.order.findMany.mockResolvedValue([
         { side: 'buy', filledQuantity: '0.5' },
@@ -162,7 +162,7 @@ describe('RiskService', () => {
       expect(result.reason).toContain('Position size limit');
     });
 
-    it('should allow when position is within limit', async () => {
+    it('포지션이 한도 내이면 허용해야 한다', async () => {
       mockPrisma.order.findFirst.mockResolvedValue(null);
       mockPrisma.order.findMany.mockResolvedValue([{ side: 'buy', filledQuantity: '0.3' }]);
 
@@ -173,7 +173,7 @@ describe('RiskService', () => {
       expect(result.allowed).toBe(true);
     });
 
-    it('should skip max position check for sell signals', async () => {
+    it('매도 시그널에는 최대 포지션 체크를 건너뛰어야 한다', async () => {
       mockPrisma.order.findMany.mockResolvedValue([]);
 
       const result = await service.checkRisk(

--- a/apps/worker-service/vitest.config.ts
+++ b/apps/worker-service/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    reporters: ['verbose'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/packages/exchange-adapters/src/binance/binance.rest.test.ts
+++ b/packages/exchange-adapters/src/binance/binance.rest.test.ts
@@ -12,8 +12,8 @@ const credentials: ExchangeCredentials = {
 const adapter = new BinanceRest();
 
 describe('BinanceRest', () => {
-  describe('getBalances', () => {
-    it('should return normalized balances', async () => {
+  describe('잔고 조회 (getBalances)', () => {
+    it('정규화된 잔고 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/account', () => {
           return HttpResponse.json({
@@ -36,7 +36,7 @@ describe('BinanceRest', () => {
       });
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/account', () => {
           return new HttpResponse('Unauthorized', { status: 401 });
@@ -47,8 +47,8 @@ describe('BinanceRest', () => {
     });
   });
 
-  describe('getOpenOrders', () => {
-    it('should return open orders', async () => {
+  describe('미체결 주문 조회 (getOpenOrders)', () => {
+    it('미체결 주문 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/openOrders', () => {
           return HttpResponse.json([
@@ -74,7 +74,7 @@ describe('BinanceRest', () => {
       expect(orders[0].side).toBe('buy');
     });
 
-    it('should return empty array for no open orders', async () => {
+    it('미체결 주문이 없으면 빈 배열을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/openOrders', () => {
           return HttpResponse.json([]);
@@ -86,8 +86,8 @@ describe('BinanceRest', () => {
     });
   });
 
-  describe('placeOrder', () => {
-    it('should place a market order', async () => {
+  describe('주문 생성 (placeOrder)', () => {
+    it('시장가 주문을 생성해야 한다', async () => {
       server.use(
         http.post('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -117,7 +117,7 @@ describe('BinanceRest', () => {
       expect(result.type).toBe('market');
     });
 
-    it('should place a limit order with GTC', async () => {
+    it('GTC 지정가 주문을 생성해야 한다', async () => {
       server.use(
         http.post('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -148,7 +148,7 @@ describe('BinanceRest', () => {
       expect(result.type).toBe('limit');
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.post('https://api.binance.com/api/v3/order', () => {
           return new HttpResponse('Insufficient balance', { status: 400 });
@@ -167,8 +167,8 @@ describe('BinanceRest', () => {
     });
   });
 
-  describe('cancelOrder', () => {
-    it('should cancel an order', async () => {
+  describe('주문 취소 (cancelOrder)', () => {
+    it('주문을 취소해야 한다', async () => {
       server.use(
         http.delete('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -189,8 +189,8 @@ describe('BinanceRest', () => {
     });
   });
 
-  describe('getOrder', () => {
-    it('should return a filled order', async () => {
+  describe('주문 조회 (getOrder)', () => {
+    it('체결 완료된 주문을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -212,7 +212,7 @@ describe('BinanceRest', () => {
       expect(result.status).toBe('filled');
     });
 
-    it('should map PARTIALLY_FILLED status', async () => {
+    it('PARTIALLY_FILLED 상태를 올바르게 매핑해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -233,7 +233,7 @@ describe('BinanceRest', () => {
       expect(result.status).toBe('partial');
     });
 
-    it('should map REJECTED status to failed', async () => {
+    it('REJECTED 상태를 failed로 매핑해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -253,7 +253,7 @@ describe('BinanceRest', () => {
       expect(result.status).toBe('failed');
     });
 
-    it('should map EXPIRED status to cancelled', async () => {
+    it('EXPIRED 상태를 cancelled로 매핑해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/order', () => {
           return HttpResponse.json({
@@ -274,8 +274,8 @@ describe('BinanceRest', () => {
     });
   });
 
-  describe('getMarkets', () => {
-    it('should return only TRADING markets', async () => {
+  describe('마켓 목록 조회 (getMarkets)', () => {
+    it('TRADING 상태의 마켓만 반환해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/exchangeInfo', () => {
           return HttpResponse.json({
@@ -299,7 +299,7 @@ describe('BinanceRest', () => {
       });
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/exchangeInfo', () => {
           return new HttpResponse('Server Error', { status: 500 });
@@ -310,8 +310,8 @@ describe('BinanceRest', () => {
     });
   });
 
-  describe('getCandles', () => {
-    it('should return normalized candles', async () => {
+  describe('캔들 조회 (getCandles)', () => {
+    it('정규화된 캔들을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/klines', () => {
           return HttpResponse.json([
@@ -363,7 +363,7 @@ describe('BinanceRest', () => {
       });
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.binance.com/api/v3/klines', () => {
           return new HttpResponse('Rate Limited', { status: 429 });

--- a/packages/exchange-adapters/src/binance/binance.ws.test.ts
+++ b/packages/exchange-adapters/src/binance/binance.ws.test.ts
@@ -54,13 +54,13 @@ describe('BinanceWebSocket', () => {
     return wsInstances[wsInstances.length - 1];
   }
 
-  it('should not connect without symbols', () => {
+  it('심볼 없이 연결하지 않아야 한다', () => {
     const before = wsInstances.length;
     ws.connect();
     expect(wsInstances.length).toBe(before);
   });
 
-  it('should connect when subscribing to ticker', async () => {
+  it('티커 구독 시 연결되어야 한다', async () => {
     ws.subscribeTicker(['BTCUSDT'], vi.fn());
     await vi.advanceTimersByTimeAsync(1);
 
@@ -68,7 +68,7 @@ describe('BinanceWebSocket', () => {
     expect(ws.isConnected()).toBe(true);
   });
 
-  it('should reconnect with new URL when symbols change', async () => {
+  it('심볼 변경 시 새 URL로 재연결해야 한다', async () => {
     ws.subscribeTicker(['BTCUSDT'], vi.fn());
     await vi.advanceTimersByTimeAsync(1);
 
@@ -78,7 +78,7 @@ describe('BinanceWebSocket', () => {
     expect(onConnected).toHaveBeenCalledTimes(2);
   });
 
-  it('should normalize 24hrTicker message', async () => {
+  it('24hrTicker 메시지를 정규화해야 한다', async () => {
     const callback = vi.fn();
     ws.subscribeTicker(['BTCUSDT'], callback);
     await vi.advanceTimersByTimeAsync(1);
@@ -113,7 +113,7 @@ describe('BinanceWebSocket', () => {
     });
   });
 
-  it('should ignore non-ticker messages', async () => {
+  it('티커가 아닌 메시지는 무시해야 한다', async () => {
     const callback = vi.fn();
     ws.subscribeTicker(['BTCUSDT'], callback);
     await vi.advanceTimersByTimeAsync(1);
@@ -122,7 +122,7 @@ describe('BinanceWebSocket', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('should auto-reconnect on close', async () => {
+  it('연결 종료 시 자동 재연결해야 한다', async () => {
     ws.subscribeTicker(['BTCUSDT'], vi.fn());
     await vi.advanceTimersByTimeAsync(1);
     const countBefore = wsInstances.length;
@@ -134,7 +134,7 @@ describe('BinanceWebSocket', () => {
     expect(wsInstances.length).toBeGreaterThan(countBefore);
   });
 
-  it('should call onError on error event', async () => {
+  it('에러 이벤트 발생 시 onError를 호출해야 한다', async () => {
     ws.subscribeTicker(['BTCUSDT'], vi.fn());
     await vi.advanceTimersByTimeAsync(1);
 
@@ -143,7 +143,7 @@ describe('BinanceWebSocket', () => {
     expect(onError).toHaveBeenCalledWith(error);
   });
 
-  it('should disconnect and cleanup', async () => {
+  it('연결 해제 후 정리되어야 한다', async () => {
     ws.subscribeTicker(['BTCUSDT'], vi.fn());
     await vi.advanceTimersByTimeAsync(1);
 

--- a/packages/exchange-adapters/src/bybit/bybit.rest.test.ts
+++ b/packages/exchange-adapters/src/bybit/bybit.rest.test.ts
@@ -16,8 +16,8 @@ function bybitOk(result: unknown) {
 }
 
 describe('BybitRest', () => {
-  describe('getBalances', () => {
-    it('should return normalized balances', async () => {
+  describe('잔고 조회 (getBalances)', () => {
+    it('정규화된 잔고 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/account/wallet-balance', () => {
           return bybitOk({
@@ -44,7 +44,7 @@ describe('BybitRest', () => {
       });
     });
 
-    it('should return empty array when no wallet data', async () => {
+    it('지갑 데이터가 없으면 빈 배열을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/account/wallet-balance', () => {
           return bybitOk({ list: [] });
@@ -55,7 +55,7 @@ describe('BybitRest', () => {
       expect(balances).toEqual([]);
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/account/wallet-balance', () => {
           return new HttpResponse('Unauthorized', { status: 401 });
@@ -65,7 +65,7 @@ describe('BybitRest', () => {
       await expect(adapter.getBalances(credentials)).rejects.toThrow('Bybit API error 401');
     });
 
-    it('should throw on retCode !== 0', async () => {
+    it('retCode가 0이 아니면 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/account/wallet-balance', () => {
           return HttpResponse.json({ retCode: 10001, retMsg: 'Invalid API key' });
@@ -78,8 +78,8 @@ describe('BybitRest', () => {
     });
   });
 
-  describe('getOpenOrders', () => {
-    it('should return open orders', async () => {
+  describe('미체결 주문 조회 (getOpenOrders)', () => {
+    it('미체결 주문 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/order/realtime', () => {
           return bybitOk({
@@ -109,7 +109,7 @@ describe('BybitRest', () => {
       expect(orders[0].type).toBe('limit');
     });
 
-    it('should return empty array when no orders', async () => {
+    it('주문이 없으면 빈 배열을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/order/realtime', () => {
           return bybitOk({ list: [] });
@@ -121,8 +121,8 @@ describe('BybitRest', () => {
     });
   });
 
-  describe('placeOrder', () => {
-    it('should place a market order', async () => {
+  describe('주문 생성 (placeOrder)', () => {
+    it('시장가 주문을 생성해야 한다', async () => {
       server.use(
         http.post('https://api.bybit.com/v5/order/create', () => {
           return bybitOk({ orderId: 'new-bybit-order' });
@@ -143,7 +143,7 @@ describe('BybitRest', () => {
       expect(result.type).toBe('market');
     });
 
-    it('should place a limit order with price and GTC', async () => {
+    it('가격과 GTC로 지정가 주문을 생성해야 한다', async () => {
       server.use(
         http.post('https://api.bybit.com/v5/order/create', () => {
           return bybitOk({ orderId: 'limit-order' });
@@ -164,7 +164,7 @@ describe('BybitRest', () => {
       expect(result.price).toBe('60000');
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.post('https://api.bybit.com/v5/order/create', () => {
           return new HttpResponse('Bad Request', { status: 400 });
@@ -183,8 +183,8 @@ describe('BybitRest', () => {
     });
   });
 
-  describe('cancelOrder', () => {
-    it('should cancel an order', async () => {
+  describe('주문 취소 (cancelOrder)', () => {
+    it('주문을 취소해야 한다', async () => {
       server.use(
         http.post('https://api.bybit.com/v5/order/cancel', () => {
           return bybitOk({ orderId: 'cancelled-order' });
@@ -197,8 +197,8 @@ describe('BybitRest', () => {
     });
   });
 
-  describe('getOrder', () => {
-    it('should return a single order', async () => {
+  describe('주문 조회 (getOrder)', () => {
+    it('단일 주문을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/order/realtime', () => {
           return bybitOk({
@@ -228,7 +228,7 @@ describe('BybitRest', () => {
       expect(result.filledPrice).toBe('50500');
     });
 
-    it('should throw when order not found', async () => {
+    it('주문을 찾을 수 없으면 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/order/realtime', () => {
           return bybitOk({ list: [] });
@@ -241,8 +241,8 @@ describe('BybitRest', () => {
     });
   });
 
-  describe('getMarkets', () => {
-    it('should return only Trading markets', async () => {
+  describe('마켓 목록 조회 (getMarkets)', () => {
+    it('Trading 상태의 마켓만 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/market/instruments-info', () => {
           return HttpResponse.json({
@@ -270,7 +270,7 @@ describe('BybitRest', () => {
       });
     });
 
-    it('should throw on retCode !== 0', async () => {
+    it('retCode가 0이 아니면 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/market/instruments-info', () => {
           return HttpResponse.json({ retCode: 10001, retMsg: 'Service unavailable', result: {} });
@@ -280,7 +280,7 @@ describe('BybitRest', () => {
       await expect(adapter.getMarkets()).rejects.toThrow('Bybit API error: Service unavailable');
     });
 
-    it('should throw on HTTP error', async () => {
+    it('HTTP 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/market/instruments-info', () => {
           return new HttpResponse('Server Error', { status: 500 });
@@ -291,8 +291,8 @@ describe('BybitRest', () => {
     });
   });
 
-  describe('getCandles', () => {
-    it('should return candles in chronological order', async () => {
+  describe('캔들 조회 (getCandles)', () => {
+    it('시간순으로 정렬된 캔들을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/market/kline', () => {
           return HttpResponse.json({
@@ -327,7 +327,7 @@ describe('BybitRest', () => {
       });
     });
 
-    it('should throw on retCode !== 0', async () => {
+    it('retCode가 0이 아니면 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/market/kline', () => {
           return HttpResponse.json({ retCode: 10001, retMsg: 'Invalid symbol', result: {} });
@@ -339,7 +339,7 @@ describe('BybitRest', () => {
       );
     });
 
-    it('should throw on HTTP error', async () => {
+    it('HTTP 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.bybit.com/v5/market/kline', () => {
           return new HttpResponse('Rate Limited', { status: 429 });

--- a/packages/exchange-adapters/src/bybit/bybit.ws.test.ts
+++ b/packages/exchange-adapters/src/bybit/bybit.ws.test.ts
@@ -54,14 +54,14 @@ describe('BybitWebSocket', () => {
     return wsInstances[wsInstances.length - 1];
   }
 
-  it('should connect and call onConnected', async () => {
+  it('연결 후 onConnected 핸들러를 호출해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     expect(onConnected).toHaveBeenCalledOnce();
     expect(ws.isConnected()).toBe(true);
   });
 
-  it('should start ping interval on connect', async () => {
+  it('연결 시 ping 인터벌을 시작해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
 
@@ -72,7 +72,7 @@ describe('BybitWebSocket', () => {
     expect(mockWs.send).toHaveBeenCalledWith(JSON.stringify({ op: 'ping' }));
   });
 
-  it('should subscribe to tickers', async () => {
+  it('티커를 구독해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
 
@@ -85,7 +85,7 @@ describe('BybitWebSocket', () => {
     );
   });
 
-  it('should normalize ticker data', async () => {
+  it('티커 데이터를 정규화해야 한다', async () => {
     const callback = vi.fn();
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
@@ -122,7 +122,7 @@ describe('BybitWebSocket', () => {
     });
   });
 
-  it('should ignore non-ticker messages', async () => {
+  it('티커가 아닌 메시지는 무시해야 한다', async () => {
     const callback = vi.fn();
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
@@ -132,7 +132,7 @@ describe('BybitWebSocket', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('should auto-reconnect on close', async () => {
+  it('연결 종료 시 자동 재연결해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     const countBefore = wsInstances.length;
@@ -144,7 +144,7 @@ describe('BybitWebSocket', () => {
     expect(wsInstances.length).toBeGreaterThan(countBefore);
   });
 
-  it('should call onError on error event', async () => {
+  it('에러 이벤트 발생 시 onError를 호출해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
 
@@ -153,7 +153,7 @@ describe('BybitWebSocket', () => {
     expect(onError).toHaveBeenCalledWith(error);
   });
 
-  it('should disconnect and cleanup', async () => {
+  it('연결 해제 후 정리되어야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
 
@@ -161,7 +161,7 @@ describe('BybitWebSocket', () => {
     expect(ws.isConnected()).toBe(false);
   });
 
-  it('should not duplicate connections', async () => {
+  it('중복 연결을 생성하지 않아야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     const count = wsInstances.length;

--- a/packages/exchange-adapters/src/upbit/upbit.rest.test.ts
+++ b/packages/exchange-adapters/src/upbit/upbit.rest.test.ts
@@ -12,8 +12,8 @@ const credentials: ExchangeCredentials = {
 const adapter = new UpbitRest();
 
 describe('UpbitRest', () => {
-  describe('getBalances', () => {
-    it('should return normalized balances', async () => {
+  describe('잔고 조회 (getBalances)', () => {
+    it('정규화된 잔고 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/accounts', () => {
           return HttpResponse.json([
@@ -40,7 +40,7 @@ describe('UpbitRest', () => {
       });
     });
 
-    it('should return empty array when no balances', async () => {
+    it('잔고가 없으면 빈 배열을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/accounts', () => {
           return HttpResponse.json([]);
@@ -51,7 +51,7 @@ describe('UpbitRest', () => {
       expect(balances).toEqual([]);
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/accounts', () => {
           return new HttpResponse('Unauthorized', { status: 401 });
@@ -62,8 +62,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('getOpenOrders', () => {
-    it('should return mapped open orders', async () => {
+  describe('미체결 주문 조회 (getOpenOrders)', () => {
+    it('매핑된 미체결 주문 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/orders', () => {
           return HttpResponse.json([
@@ -94,8 +94,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('placeOrder', () => {
-    it('should place a limit order', async () => {
+  describe('주문 생성 (placeOrder)', () => {
+    it('지정가 주문을 생성해야 한다', async () => {
       server.use(
         http.post('https://api.upbit.com/v1/orders', () => {
           return HttpResponse.json({
@@ -128,7 +128,7 @@ describe('UpbitRest', () => {
       expect(result.status).toBe('placed');
     });
 
-    it('should place a market sell order', async () => {
+    it('시장가 매도 주문을 생성해야 한다', async () => {
       server.use(
         http.post('https://api.upbit.com/v1/orders', () => {
           return HttpResponse.json({
@@ -163,7 +163,7 @@ describe('UpbitRest', () => {
       expect(result.side).toBe('sell');
     });
 
-    it('should place a market buy order (KRW amount)', async () => {
+    it('시장가 매수 주문을 생성해야 한다 (KRW 금액 기준)', async () => {
       server.use(
         http.post('https://api.upbit.com/v1/orders', () => {
           return HttpResponse.json({
@@ -197,7 +197,7 @@ describe('UpbitRest', () => {
       expect(result.status).toBe('filled');
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.post('https://api.upbit.com/v1/orders', () => {
           return new HttpResponse('Bad Request', { status: 400 });
@@ -216,8 +216,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('cancelOrder', () => {
-    it('should cancel an order', async () => {
+  describe('주문 취소 (cancelOrder)', () => {
+    it('주문을 취소해야 한다', async () => {
       server.use(
         http.delete('https://api.upbit.com/v1/order', () => {
           return HttpResponse.json({
@@ -242,8 +242,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('getOrder', () => {
-    it('should return a single order', async () => {
+  describe('주문 조회 (getOrder)', () => {
+    it('단일 주문을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/order', () => {
           return HttpResponse.json({
@@ -272,8 +272,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('getMarkets', () => {
-    it('should return normalized markets', async () => {
+  describe('마켓 목록 조회 (getMarkets)', () => {
+    it('정규화된 마켓 목록을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/market/all', () => {
           return HttpResponse.json([
@@ -294,7 +294,7 @@ describe('UpbitRest', () => {
       });
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/market/all', () => {
           return new HttpResponse('Server Error', { status: 500 });
@@ -305,8 +305,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('getCandles', () => {
-    it('should return normalized candles in chronological order', async () => {
+  describe('캔들 조회 (getCandles)', () => {
+    it('시간순으로 정렬된 정규화된 캔들을 반환해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/candles/minutes/60', () => {
           return HttpResponse.json([
@@ -343,7 +343,7 @@ describe('UpbitRest', () => {
       expect(candles[0].close).toBe('50500000');
     });
 
-    it('should map interval correctly', async () => {
+    it('인터벌을 올바르게 매핑해야 한다', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
       server.use(
@@ -362,7 +362,7 @@ describe('UpbitRest', () => {
       fetchSpy.mockRestore();
     });
 
-    it('should throw on API error', async () => {
+    it('API 에러 시 예외를 던져야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/candles/*', () => {
           return new HttpResponse('Rate Limited', { status: 429 });
@@ -373,8 +373,8 @@ describe('UpbitRest', () => {
     });
   });
 
-  describe('mapOrderResponse edge cases', () => {
-    it('should calculate filledPrice from trades when executed_funds is missing', async () => {
+  describe('주문 응답 매핑 엣지 케이스 (mapOrderResponse)', () => {
+    it('executed_funds가 없을 때 체결 내역에서 체결가를 계산해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/order', () => {
           return HttpResponse.json({
@@ -420,7 +420,7 @@ describe('UpbitRest', () => {
       expect(result.filledPrice).toBe(String(100100 / 0.002));
     });
 
-    it('should handle "watch" state as placed', async () => {
+    it('"watch" 상태를 placed로 처리해야 한다', async () => {
       server.use(
         http.get('https://api.upbit.com/v1/order', () => {
           return HttpResponse.json({

--- a/packages/exchange-adapters/src/upbit/upbit.ws.test.ts
+++ b/packages/exchange-adapters/src/upbit/upbit.ws.test.ts
@@ -55,26 +55,26 @@ describe('UpbitWebSocket', () => {
     return wsInstances[wsInstances.length - 1];
   }
 
-  it('should connect and call onConnected handler', async () => {
+  it('연결 후 onConnected 핸들러를 호출해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     expect(onConnected).toHaveBeenCalledOnce();
   });
 
-  it('should report isConnected correctly after connect', async () => {
+  it('연결 후 isConnected가 올바른 값을 반환해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     expect(ws.isConnected()).toBe(true);
   });
 
-  it('should disconnect and cleanup', async () => {
+  it('연결 해제 후 정리되어야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     ws.disconnect();
     expect(ws.isConnected()).toBe(false);
   });
 
-  it('should send subscription when subscribing after connect', async () => {
+  it('연결 후 구독 시 구독 메시지를 전송해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
 
@@ -86,7 +86,7 @@ describe('UpbitWebSocket', () => {
     expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('KRW-BTC'));
   });
 
-  it('should normalize ticker data from message', async () => {
+  it('메시지에서 티커 데이터를 정규화해야 한다', async () => {
     const callback = vi.fn();
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
@@ -122,7 +122,7 @@ describe('UpbitWebSocket', () => {
     });
   });
 
-  it('should auto-reconnect on close after 3 seconds', async () => {
+  it('연결 종료 후 3초 뒤 자동 재연결해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     const countBefore = wsInstances.length;
@@ -134,7 +134,7 @@ describe('UpbitWebSocket', () => {
     expect(wsInstances.length).toBeGreaterThan(countBefore);
   });
 
-  it('should call onError handler on error', async () => {
+  it('에러 발생 시 onError 핸들러를 호출해야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
 
@@ -143,7 +143,7 @@ describe('UpbitWebSocket', () => {
     expect(onError).toHaveBeenCalledWith(error);
   });
 
-  it('should not create duplicate connections', async () => {
+  it('중복 연결을 생성하지 않아야 한다', async () => {
     ws.connect();
     await vi.advanceTimersByTimeAsync(1);
     const count = wsInstances.length;

--- a/packages/exchange-adapters/vitest.config.ts
+++ b/packages/exchange-adapters/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    reporters: ['verbose'],
     include: ['src/**/*.test.ts'],
     setupFiles: ['./src/test-setup.ts'],
     coverage: {

--- a/packages/utils/src/crypto.test.ts
+++ b/packages/utils/src/crypto.test.ts
@@ -6,33 +6,33 @@ const TEST_KEY = 'a'.repeat(64);
 const ANOTHER_KEY = 'b'.repeat(64);
 
 describe('encrypt/decrypt', () => {
-  it('should encrypt and decrypt a string (round trip)', () => {
+  it('문자열 암호화 후 복호화하면 원본과 동일해야 한다', () => {
     const plaintext = 'my-secret-api-key';
     const encrypted = encrypt(plaintext, TEST_KEY);
     const decrypted = decrypt(encrypted, TEST_KEY);
     expect(decrypted).toBe(plaintext);
   });
 
-  it('should produce different ciphertext for the same plaintext (random IV)', () => {
+  it('동일한 평문이라도 매번 다른 암호문을 생성해야 한다 (랜덤 IV)', () => {
     const plaintext = 'same-text';
     const a = encrypt(plaintext, TEST_KEY);
     const b = encrypt(plaintext, TEST_KEY);
     expect(a).not.toBe(b);
   });
 
-  it('should fail decryption with a wrong key', () => {
+  it('잘못된 키로 복호화하면 실패해야 한다', () => {
     const encrypted = encrypt('secret', TEST_KEY);
     expect(() => decrypt(encrypted, ANOTHER_KEY)).toThrow();
   });
 
-  it('should handle unicode strings', () => {
+  it('유니코드 문자열을 처리할 수 있어야 한다', () => {
     const plaintext = '한글 테스트 🚀';
     const encrypted = encrypt(plaintext, TEST_KEY);
     const decrypted = decrypt(encrypted, TEST_KEY);
     expect(decrypted).toBe(plaintext);
   });
 
-  it('should throw on invalid encrypted format', () => {
+  it('잘못된 암호문 형식이면 에러를 던져야 한다', () => {
     expect(() => decrypt('invalid-format', TEST_KEY)).toThrow('Invalid encrypted format');
   });
 });

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    reporters: ['verbose'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- AuthService, TokenService, SagaStepRunner 단위 테스트 추가 (20개)
- 전체 33개 테스트 파일의 describe/it 문자열을 한글로 변환
- 모든 vitest config에 `reporters: ['verbose']` 추가 (CI에서 개별 테스트명 확인 가능)

## 신규 테스트

| 파일 | 테스트 수 | 주요 시나리오 |
|------|-----------|-------------|
| `auth.service.test.ts` | 8 | 회원가입, 이메일 중복, OAuth 연결/생성, 로컬 검증, 사용자 조회 |
| `token.service.test.ts` | 7 | 토큰 발급, 리프레시 갱신, 토큰 폐기, 유효하지 않은 토큰 |
| `saga-step-runner.test.ts` | 5 | 순차 실행, 역순 보상, completed/failed 상태, 멱등성 |

## 한글화 예시
```
✓ AuthService > 회원가입 (signup) > 새 사용자를 생성해야 한다
✓ TokenService > 리프레시 토큰 갱신 > 유효하지 않은 리프레시 토큰이면 예외를 던져야 한다
✓ SagaStepRunner > 실패 시 역순으로 보상해야 한다
✓ UpbitRest > 잔고 조회 > 정규화된 잔고 목록을 반환해야 한다
```

## 누적 테스트 현황
| 영역 | 테스트 수 |
|------|----------|
| api-server | 68 |
| worker-service | 31 |
| exchange-adapters | 76 |
| utils | 5 |
| **합계** | **180** |

## Closes #50

## Test plan
- [x] `pnpm turbo run test:unit` — 180 tests passed (verbose)
- [x] `pnpm turbo run build` — 전체 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add authentication and saga unit tests, localize test descriptions to Korean, and enhance test reporting configuration across packages.

Build:
- Enable verbose test reporting via `reporters: ['verbose']` in vitest config for all apps and packages to surface individual test names in CI.

Tests:
- Add unit tests for AuthService covering signup flows, local credential validation, OAuth user handling, and user lookup.
- Add unit tests for TokenService covering token pair issuance, refresh token rotation error cases, and refresh token revocation behavior.
- Add unit tests for SagaStepRunner validating sequential execution, compensating on failure, saga status transitions, and idempotent re-runs.
- Localize existing exchange adapter, strategy, risk, orders, exchange-keys, notifications, portfolio, and strategy query/command tests to Korean for describe/it descriptions.