### PR TITLE
fix: sourcery-ai 리뷰 반영 — bcrypt 솔트 하드코딩 제거, verbose CI 전용

### DIFF
--- a/apps/api-server/src/auth/auth.service.test.ts
+++ b/apps/api-server/src/auth/auth.service.test.ts
@@ -29,7 +29,7 @@ describe('AuthService', () => {
 
       const result = await service.signup({ email: 'test@test.com', password: 'pass123' } as never);
       expect(result.id).toBe('u1');
-      expect(bcrypt.hash).toHaveBeenCalledWith('pass123', 10);
+      expect(bcrypt.hash).toHaveBeenCalledWith('pass123', expect.any(Number));
     });
 
     it('이미 비밀번호로 등록된 이메일이면 ConflictException을 던져야 한다', async () => {

--- a/apps/api-server/vitest.config.ts
+++ b/apps/api-server/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
-    reporters: ['verbose'],
+    reporters: process.env.CI ? ['verbose'] : ['default'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
-    reporters: ['verbose'],
+    reporters: process.env.CI ? ['verbose'] : ['default'],
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./src/test-setup.ts'],

--- a/apps/worker-service/vitest.config.ts
+++ b/apps/worker-service/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
-    reporters: ['verbose'],
+    reporters: process.env.CI ? ['verbose'] : ['default'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/packages/exchange-adapters/vitest.config.ts
+++ b/packages/exchange-adapters/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
-    reporters: ['verbose'],
+    reporters: process.env.CI ? ['verbose'] : ['default'],
     include: ['src/**/*.test.ts'],
     setupFiles: ['./src/test-setup.ts'],
     coverage: {

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
-    reporters: ['verbose'],
+    reporters: process.env.CI ? ['verbose'] : ['default'],
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
PR #60에 대한 sourcery-ai 리뷰 피드백 반영

## 변경사항

### 1. bcrypt.hash 솔트 라운드 하드코딩 제거
```diff
- expect(bcrypt.hash).toHaveBeenCalledWith('pass123', 10);
+ expect(bcrypt.hash).toHaveBeenCalledWith('pass123', expect.any(Number));
```
구현 세부사항(솔트 라운드 값)에 결합하지 않도록 수정

### 2. verbose reporter CI 환경에서만 적용
```diff
- reporters: ['verbose'],
+ reporters: process.env.CI ? ['verbose'] : ['default'],
```
로컬에서는 default(간결한) 출력, CI에서만 verbose(상세) 출력

## Test plan
- [x] `pnpm turbo run test:unit` — 180 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Relax test coupling to bcrypt salt rounds and scope verbose test reporting to CI environments across packages.

Bug Fixes:
- Loosen the AuthService signup test to assert bcrypt.hash is called with a numeric salt value instead of a specific hard-coded round.

Enhancements:
- Configure Vitest reporters to use verbose output only in CI while defaulting to a simpler reporter for local runs across apps and packages.