### PR TITLE
feat(backend): Strategy 테이블 order 필드 추가 및 reorder API 구현 (PRO-64)

### DIFF
--- a/apps/api-server/src/strategies/commands/index.ts
+++ b/apps/api-server/src/strategies/commands/index.ts
@@ -2,15 +2,18 @@ import { CreateStrategyHandler } from './create-strategy.handler';
 import { UpdateStrategyHandler } from './update-strategy.handler';
 import { ToggleStrategyHandler } from './toggle-strategy.handler';
 import { DeleteStrategyHandler } from './delete-strategy.handler';
+import { ReorderStrategiesHandler } from './reorder-strategies.handler';
 
 export const StrategyCommandHandlers = [
   CreateStrategyHandler,
   UpdateStrategyHandler,
   ToggleStrategyHandler,
   DeleteStrategyHandler,
+  ReorderStrategiesHandler,
 ];
 
 export { CreateStrategyCommand } from './create-strategy.command';
 export { UpdateStrategyCommand } from './update-strategy.command';
 export { ToggleStrategyCommand } from './toggle-strategy.command';
 export { DeleteStrategyCommand } from './delete-strategy.command';
+export { ReorderStrategiesCommand } from './reorder-strategies.command';

--- a/apps/api-server/src/strategies/commands/reorder-strategies.command.ts
+++ b/apps/api-server/src/strategies/commands/reorder-strategies.command.ts
@@ -1,0 +1,8 @@
+import { ReorderStrategiesDto } from '../dto/reorder-strategies.dto';
+
+export class ReorderStrategiesCommand {
+  constructor(
+    public readonly userId: string,
+    public readonly dto: ReorderStrategiesDto,
+  ) {}
+}

--- a/apps/api-server/src/strategies/commands/reorder-strategies.handler.test.ts
+++ b/apps/api-server/src/strategies/commands/reorder-strategies.handler.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { ReorderStrategiesHandler } from './reorder-strategies.handler';
+import { ReorderStrategiesCommand } from './reorder-strategies.command';
+
+const mockPrisma = {
+  strategy: {
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+
+describe('ReorderStrategiesHandler', () => {
+  let handler: ReorderStrategiesHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new ReorderStrategiesHandler(mockPrisma as never);
+  });
+
+  it('전략 순서를 일괄 업데이트해야 한다', async () => {
+    mockPrisma.strategy.findMany.mockResolvedValue([{ id: 'strat-1' }, { id: 'strat-2' }]);
+    mockPrisma.$transaction.mockResolvedValue([]);
+
+    await handler.execute(
+      new ReorderStrategiesCommand('user-1', {
+        orders: [
+          { id: 'strat-1', order: 0 },
+          { id: 'strat-2', order: 1 },
+        ],
+      }),
+    );
+
+    expect(mockPrisma.strategy.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: ['strat-1', 'strat-2'] }, userId: 'user-1' } }),
+    );
+    expect(mockPrisma.$transaction).toHaveBeenCalled();
+  });
+
+  it('빈 orders 배열이면 아무 작업도 하지 않아야 한다', async () => {
+    await handler.execute(new ReorderStrategiesCommand('user-1', { orders: [] }));
+
+    expect(mockPrisma.strategy.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('소유하지 않은 전략 ID가 포함되면 예외를 던져야 한다', async () => {
+    mockPrisma.strategy.findMany.mockResolvedValue([{ id: 'strat-1' }]);
+
+    await expect(
+      handler.execute(
+        new ReorderStrategiesCommand('user-1', {
+          orders: [
+            { id: 'strat-1', order: 0 },
+            { id: 'strat-99', order: 1 },
+          ],
+        }),
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api-server/src/strategies/commands/reorder-strategies.handler.ts
+++ b/apps/api-server/src/strategies/commands/reorder-strategies.handler.ts
@@ -1,0 +1,35 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ReorderStrategiesCommand } from './reorder-strategies.command';
+
+@CommandHandler(ReorderStrategiesCommand)
+export class ReorderStrategiesHandler implements ICommandHandler<ReorderStrategiesCommand> {
+  private readonly logger = new Logger(ReorderStrategiesHandler.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async execute(command: ReorderStrategiesCommand): Promise<void> {
+    const { userId, dto } = command;
+
+    if (!dto.orders.length) return;
+
+    const ids = dto.orders.map((o) => o.id);
+    const owned = await this.prisma.strategy.findMany({
+      where: { id: { in: ids }, userId },
+      select: { id: true },
+    });
+
+    if (owned.length !== ids.length) {
+      throw new BadRequestException('One or more strategy IDs are invalid or not owned by user');
+    }
+
+    await this.prisma.$transaction(
+      dto.orders.map(({ id, order }) =>
+        this.prisma.strategy.update({ where: { id }, data: { order } }),
+      ),
+    );
+
+    this.logger.log(`Reordered ${dto.orders.length} strategies for user ${userId}`);
+  }
+}

--- a/apps/api-server/src/strategies/dto/reorder-strategies.dto.ts
+++ b/apps/api-server/src/strategies/dto/reorder-strategies.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, IsString, Min, ValidateNested } from 'class-validator';
+
+export class StrategyOrderItem {
+  @ApiProperty({ description: '전략 ID' })
+  @IsString()
+  id!: string;
+
+  @ApiProperty({ description: '새 순서 값 (0-based)' })
+  @IsInt()
+  @Min(0)
+  order!: number;
+}
+
+export class ReorderStrategiesDto {
+  @ApiProperty({ description: '순서 업데이트할 전략 목록', type: [StrategyOrderItem] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => StrategyOrderItem)
+  orders!: StrategyOrderItem[];
+}

--- a/apps/api-server/src/strategies/dto/strategy-response.dto.ts
+++ b/apps/api-server/src/strategies/dto/strategy-response.dto.ts
@@ -37,6 +37,9 @@ export class StrategyResponse {
   @ApiProperty({ description: '캔들 간격' })
   candleInterval!: string;
 
+  @ApiProperty({ description: '표시 순서' })
+  order!: number;
+
   @ApiProperty({ description: '생성일시' })
   createdAt!: string;
 

--- a/apps/api-server/src/strategies/queries/get-strategies.handler.ts
+++ b/apps/api-server/src/strategies/queries/get-strategies.handler.ts
@@ -9,7 +9,7 @@ export class GetStrategiesHandler implements IQueryHandler<GetStrategiesQuery> {
   async execute(query: GetStrategiesQuery): Promise<unknown[]> {
     return this.prisma.strategy.findMany({
       where: { userId: query.userId },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
     });
   }
 }

--- a/apps/api-server/src/strategies/strategies.controller.ts
+++ b/apps/api-server/src/strategies/strategies.controller.ts
@@ -25,6 +25,7 @@ import {
   UpdateStrategyCommand,
   ToggleStrategyCommand,
   DeleteStrategyCommand,
+  ReorderStrategiesCommand,
 } from './commands';
 import {
   GetStrategiesQuery,
@@ -35,6 +36,7 @@ import {
 } from './queries';
 import { CreateStrategyDto } from './dto/create-strategy.dto';
 import { UpdateStrategyDto } from './dto/update-strategy.dto';
+import { ReorderStrategiesDto } from './dto/reorder-strategies.dto';
 import {
   StrategyResponse,
   StrategyPerformanceResponse,
@@ -134,6 +136,20 @@ export class StrategiesController {
   @ApiParam({ name: 'id', description: '전략 ID' })
   async toggle(@CurrentUser() user: User, @Param('id') id: string) {
     return this.commandBus.execute(new ToggleStrategyCommand(user.id, id));
+  }
+
+  @Patch('reorder')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: '전략 카드 순서 일괄 업데이트',
+    description:
+      '전략 목록의 표시 순서를 업데이트합니다. DnD 후 변경된 순서를 저장할 때 사용합니다.',
+  })
+  @ApiResponse({ status: 204, description: '순서 업데이트 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 전략 ID 또는 권한 없음' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  async reorder(@CurrentUser() user: User, @Body() dto: ReorderStrategiesDto) {
+    return this.commandBus.execute(new ReorderStrategiesCommand(user.id, dto));
   }
 
   @Delete(':id')

--- a/packages/database/prisma/migrations/20260401100000_add_strategy_order/migration.sql
+++ b/packages/database/prisma/migrations/20260401100000_add_strategy_order/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "Strategy" ADD COLUMN "order" INTEGER NOT NULL DEFAULT 0;
+
+-- BackfillData: assign initial order values based on createdAt per user
+WITH ranked AS (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY "userId" ORDER BY "createdAt" ASC) - 1 AS rn
+  FROM "Strategy"
+)
+UPDATE "Strategy"
+SET "order" = ranked.rn
+FROM ranked
+WHERE "Strategy".id = ranked.id;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -109,6 +109,7 @@ model Strategy {
   riskConfig      Json          @default("{}")
   intervalSeconds Int           @default(60)
   candleInterval  String        @default("1h")
+  order           Int           @default(0)
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
   user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
- Prisma schema에 Strategy.order Int @default(0) 필드 추가
- 마이그레이션: order 컬럼 추가 + createdAt 기준 초기값 backfill
- GET /strategies: createdAt desc → [order asc, createdAt asc] 정렬 변경
- PATCH /strategies/reorder: 순서 일괄 업데이트 엔드포인트 추가
- StrategyResponse DTO에 order 필드 포함
- ReorderStrategiesHandler 단위 테스트 추가

## Summary by Sourcery

Add support for ordering strategy cards and exposing their order in API responses.

New Features:
- Expose an order field on strategies and include it in the StrategyResponse DTO.
- Add a PATCH /strategies/reorder endpoint to batch update strategy display order for a user.

Enhancements:
- Change strategy list sorting to use the configurable order field with createdAt as a secondary key.

Build:
- Add a Prisma migration to introduce the Strategy.order column and backfill initial values based on createdAt per user.

Tests:
- Add unit tests for the ReorderStrategiesHandler, covering normal operation, empty input, and invalid or unauthorized IDs.