### PR TITLE
[PRO-92] fix: normalize symbol to uppercase before Binance API calls

### DIFF
--- a/apps/worker-service/src/backtesting/data.service.ts
+++ b/apps/worker-service/src/backtesting/data.service.ts
@@ -30,6 +30,7 @@ export class DataService {
     startTime: number,
     endTime: number,
   ): Promise<OhlcvCandle[]> {
+    symbol = symbol.toUpperCase();
     const stored = await this.loadFromDb(exchange, symbol, interval, startTime, endTime);
     if (stored.length > 0) {
       return stored;

--- a/apps/worker-service/src/backtests/backtests.service.ts
+++ b/apps/worker-service/src/backtests/backtests.service.ts
@@ -222,6 +222,7 @@ export class BacktestsService implements OnModuleInit, OnModuleDestroy {
     startDate: Date,
     endDate: Date,
   ): Promise<Candle[]> {
+    symbol = symbol.toUpperCase();
     const cacheKey = `backtest:candles:${exchange}:${symbol}:${interval}:${startDate.toISOString()}:${endDate.toISOString()}`;
     const cached = await this.redis.get(cacheKey);
     if (cached) {


### PR DESCRIPTION
## Summary

- Normalizes `symbol` to uppercase at the entry point of both backtest service paths before any DB key or Binance API call
- Fixes Binance API error -1100: `Illegal characters found in parameter 'symbol'`

## Changes

- `apps/worker-service/src/backtests/backtests.service.ts` — `fetchHistoricalCandles()`: `symbol = symbol.toUpperCase()`
- `apps/worker-service/src/backtesting/data.service.ts` — `getCandles()`: `symbol = symbol.toUpperCase()`

## Related

- Closes [PRO-92](https://github.com/fray-cloud/coin/issues) (internal: /PRO/issues/PRO-92)
- Parent: [PRO-91](/PRO/issues/PRO-91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent Binance API errors caused by mixed-case or lowercase symbols in backtest and data service candle queries.