### PR TITLE
[PRO-93] feat: apply select box to condition node enum parameters

### DIFF
--- a/apps/web/src/components/flows/node-inspector.tsx
+++ b/apps/web/src/components/flows/node-inspector.tsx
@@ -40,11 +40,28 @@ function ParamInput({
   paramKey,
   value,
   onChange,
+  options,
 }: {
   paramKey: string;
   value: unknown;
   onChange: (val: unknown) => void;
+  options?: string[];
 }) {
+  if (options && options.length > 0) {
+    return (
+      <select
+        value={String(value)}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:border-primary"
+      >
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {PARAM_VALUE_LABELS[opt] ?? opt}
+          </option>
+        ))}
+      </select>
+    );
+  }
   if (typeof value === 'boolean') {
     return (
       <button
@@ -133,7 +150,7 @@ export function NodeInspector() {
         {params ? (
           <div className="flex flex-col gap-2">
             {/* Required params — always shown */}
-            {requiredParams.map(({ key }) => (
+            {requiredParams.map(({ key, options }) => (
               <label key={key} className="flex flex-col gap-0.5">
                 <span className="text-[10px] text-muted-foreground">
                   {PARAM_LABELS[key] ?? key}
@@ -142,6 +159,7 @@ export function NodeInspector() {
                   paramKey={key}
                   value={config[key] ?? registry.defaultConfig[key]}
                   onChange={(val) => updateNodeConfig(node.id, { [key]: val })}
+                  options={options}
                 />
               </label>
             ))}
@@ -154,7 +172,7 @@ export function NodeInspector() {
                     선택적 파라미터
                   </span>
                 </div>
-                {optionalParams.map(({ key }) => {
+                {optionalParams.map(({ key, options }) => {
                   const isEnabled = key in config;
                   const defaultVal = registry.defaultConfig[key];
                   return (
@@ -183,6 +201,7 @@ export function NodeInspector() {
                           paramKey={key}
                           value={config[key]}
                           onChange={(val) => updateNodeConfig(node.id, { [key]: val })}
+                          options={options}
                         />
                       ) : (
                         <span className="rounded border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground/40">

--- a/packages/types/src/flow.ts
+++ b/packages/types/src/flow.ts
@@ -36,6 +36,7 @@ export interface PortDefinition {
 export interface ParamDefinition {
   key: string;
   required: boolean;
+  options?: string[];
 }
 
 export interface NodeTypeInfo {
@@ -75,7 +76,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeInfo> = {
     defaultConfig: { period: 14, source: 'close' },
     params: [
       { key: 'period', required: true },
-      { key: 'source', required: false },
+      { key: 'source', required: false, options: ['close', 'open', 'high', 'low'] },
     ],
   },
   macd: {
@@ -128,7 +129,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeInfo> = {
     outputs: [{ name: 'result', type: 'boolean' }],
     defaultConfig: { operator: '<', threshold: 30 },
     params: [
-      { key: 'operator', required: true },
+      { key: 'operator', required: true, options: ['<', '>', '<=', '>=', '=='] },
       { key: 'threshold', required: true },
     ],
   },
@@ -142,7 +143,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeInfo> = {
     ],
     outputs: [{ name: 'result', type: 'boolean' }],
     defaultConfig: { direction: 'above' },
-    params: [{ key: 'direction', required: true }],
+    params: [{ key: 'direction', required: true, options: ['above', 'below'] }],
   },
   'and-or': {
     subtype: 'and-or',
@@ -154,7 +155,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeInfo> = {
     ],
     outputs: [{ name: 'result', type: 'boolean' }],
     defaultConfig: { operator: 'AND' },
-    params: [{ key: 'operator', required: true }],
+    params: [{ key: 'operator', required: true, options: ['AND', 'OR'] }],
   },
   'market-order': {
     subtype: 'market-order',
@@ -164,7 +165,7 @@ export const NODE_TYPE_REGISTRY: Record<string, NodeTypeInfo> = {
     outputs: [{ name: 'result', type: 'OrderResult' }],
     defaultConfig: { side: 'buy', amount: '0.001' },
     params: [
-      { key: 'side', required: true },
+      { key: 'side', required: true, options: ['buy', 'sell'] },
       { key: 'amount', required: true },
     ],
   },


### PR DESCRIPTION
## Summary

- Adds `options?: string[]` to `ParamDefinition` type so node parameters can declare fixed enum values
- Renders a `<select>` dropdown in `ParamInput` when `options` are present (localized via `PARAM_VALUE_LABELS`)
- Applies options to: AND/OR operator, crossover direction, threshold operator, market-order side, RSI source

## Changes

- `packages/types/src/flow.ts` — add `options` field to `ParamDefinition`
- `apps/web/src/components/flows/node-inspector.tsx` — conditional `<select>` render + Korean labels

## Related

- Closes [PRO-93](https://github.com/fray-cloud/coin/issues) (internal: /PRO/issues/PRO-93)
- Parent: [PRO-91](/PRO/issues/PRO-91)
- Related: [PRO-80](/PRO/issues/PRO-80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce enum-style parameter options to flow nodes and render them as select dropdowns in the node inspector UI.

New Features:
- Allow node parameter definitions to declare fixed option lists for their values.
- Render select dropdown inputs in the node inspector when parameters specify predefined options.

Enhancements:
- Define option lists for several existing node parameters, including RSI source, comparison operators, crossover direction, logical operators, and market-order side.