### PR TITLE
feat: UI/UX overhaul — testnet/mainnet split, USD/KRW toggle, /orders/[id], dashboard rebuild

### DIFF
--- a/apps/api-server/src/activity/activity.service.test.ts
+++ b/apps/api-server/src/activity/activity.service.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ActivityService } from './activity.service';
+
+const mockPrisma = {
+  order: { findMany: vi.fn() },
+  loginHistory: { findMany: vi.fn() },
+};
+
+describe('ActivityService', () => {
+  let svc: ActivityService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new ActivityService(mockPrisma as never);
+  });
+
+  it('주문 활동 항목은 /orders/${id} 로 링크된다', async () => {
+    mockPrisma.order.findMany.mockResolvedValue([
+      {
+        id: 'order-abc',
+        side: 'long',
+        symbol: 'BTCUSDT',
+        type: 'market',
+        quantity: '0.01',
+        filledPrice: '60000',
+        price: null,
+        mode: 'real',
+        exchange: 'binance',
+        status: 'filled',
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+      },
+    ]);
+    mockPrisma.loginHistory.findMany.mockResolvedValue([]);
+
+    const { items } = await svc.getActivity('user-1');
+    const orderItem = items.find((i) => i.type === 'order');
+    expect(orderItem?.link).toBe('/orders/order-abc');
+  });
+});

--- a/apps/api-server/src/activity/activity.service.ts
+++ b/apps/api-server/src/activity/activity.service.ts
@@ -53,7 +53,7 @@ export class ActivityService {
       symbol: o.symbol,
       status: o.status,
       side: o.side,
-      link: '/orders',
+      link: `/orders/${o.id}`,
       createdAt: o.createdAt,
     }));
 

--- a/apps/api-server/src/app.module.ts
+++ b/apps/api-server/src/app.module.ts
@@ -15,6 +15,7 @@ import { PortfolioModule } from './portfolio/portfolio.module';
 import { ActivityModule } from './activity/activity.module';
 import { ClaudeTokensModule } from './claude-tokens/claude-tokens.module';
 import { LlmTradesModule } from './llm-trades/llm-trades.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 import { DebugModule } from './debug/debug.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
@@ -53,6 +54,7 @@ import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
     ActivityModule,
     ClaudeTokensModule,
     LlmTradesModule,
+    DashboardModule,
     DebugModule,
   ],
   controllers: [AppController],

--- a/apps/api-server/src/dashboard/dashboard.controller.ts
+++ b/apps/api-server/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { DashboardService } from './dashboard.service';
+
+@ApiTags('Dashboard')
+@ApiBearerAuth('access-token')
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly service: DashboardService) {}
+
+  @Get('summary')
+  @ApiOperation({
+    summary: '대시보드 단일 집계 (오늘/이번주 PnL · 활성 포지션 · 최근 LLM 결정)',
+  })
+  summary(@CurrentUser() user: { id: string }) {
+    return this.service.getSummary(user.id);
+  }
+}

--- a/apps/api-server/src/dashboard/dashboard.module.ts
+++ b/apps/api-server/src/dashboard/dashboard.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/apps/api-server/src/dashboard/dashboard.service.ts
+++ b/apps/api-server/src/dashboard/dashboard.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import type { Ticker } from '@coin/types';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface NetworkPnlBucket {
+  testnet: number;
+  mainnet: number;
+}
+
+@Injectable()
+export class DashboardService {
+  private redis: Redis;
+
+  constructor(private readonly prisma: PrismaService) {
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+  }
+
+  async getSummary(userId: string) {
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+    const startOfWeek = new Date(startOfToday);
+    startOfWeek.setDate(startOfWeek.getDate() - 6);
+
+    const [todayOrders, weekOrders, openPositions, recentDecisions] = await Promise.all([
+      this.prisma.order.findMany({
+        where: {
+          userId,
+          status: { in: ['filled', 'closed'] },
+          updatedAt: { gte: startOfToday },
+          realizedPnl: { not: null },
+        },
+        include: { exchangeKey: { select: { network: true } } },
+      }),
+      this.prisma.order.findMany({
+        where: {
+          userId,
+          status: { in: ['filled', 'closed'] },
+          updatedAt: { gte: startOfWeek },
+          realizedPnl: { not: null },
+        },
+        include: { exchangeKey: { select: { network: true } } },
+      }),
+      this.prisma.order.findMany({
+        where: { userId, status: 'filled', closedAt: null, mode: 'real' },
+        include: { exchangeKey: { select: { network: true } } },
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.llmDecisionLog.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        include: {
+          order: {
+            select: {
+              id: true,
+              status: true,
+              symbol: true,
+              side: true,
+              entryPrice: true,
+              takeProfitPrice: true,
+              stopLossPrice: true,
+              realizedPnl: true,
+              closedAt: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const positionsWithMark = await Promise.all(
+      openPositions.map(async (p) => {
+        const markPrice = await this.fetchMarkPrice(p.exchange, p.symbol);
+        const unrealizedPnl = this.computeUnrealizedPnl(p, markPrice);
+        return { ...p, markPrice, unrealizedPnl };
+      }),
+    );
+
+    return {
+      pnl: {
+        today: this.bucketByNetwork(todayOrders),
+        week: this.bucketByNetwork(weekOrders),
+      },
+      openPositions: positionsWithMark,
+      recentDecisions,
+    };
+  }
+
+  private bucketByNetwork(
+    rows: Array<{ realizedPnl: string | null; exchangeKey: { network: string } | null }>,
+  ): NetworkPnlBucket {
+    const acc: NetworkPnlBucket = { testnet: 0, mainnet: 0 };
+    for (const r of rows) {
+      const v = Number(r.realizedPnl ?? 0);
+      if (!Number.isFinite(v)) continue;
+      const net = (r.exchangeKey?.network ?? 'mainnet') as keyof NetworkPnlBucket;
+      acc[net] += v;
+    }
+    acc.testnet = Math.round(acc.testnet * 100) / 100;
+    acc.mainnet = Math.round(acc.mainnet * 100) / 100;
+    return acc;
+  }
+
+  private async fetchMarkPrice(exchange: string, symbol: string): Promise<number | null> {
+    const data = await this.redis.get(`ticker:${exchange}:${symbol}`);
+    if (!data) return null;
+    const ticker: Ticker = JSON.parse(data);
+    const n = Number(ticker.price);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  private computeUnrealizedPnl(
+    order: { side: string; entryPrice: string | null; filledQuantity: string },
+    markPrice: number | null,
+  ): number | null {
+    if (markPrice == null) return null;
+    const entry = Number(order.entryPrice ?? 0);
+    const qty = Number(order.filledQuantity ?? 0);
+    if (!entry || !qty) return null;
+    const direction = order.side === 'long' ? 1 : -1;
+    return Math.round((markPrice - entry) * qty * direction * 100) / 100;
+  }
+}

--- a/apps/api-server/src/llm-trades/llm-trades.controller.ts
+++ b/apps/api-server/src/llm-trades/llm-trades.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { LlmTradesService } from './llm-trades.service';
@@ -27,5 +27,20 @@ export class LlmTradesController {
   })
   execute(@CurrentUser() user: { id: string }, @Body() dto: ExecuteTradeDto) {
     return this.service.execute(user.id, dto);
+  }
+
+  @Get('decisions')
+  @ApiOperation({
+    summary: 'List recent LLM decisions for the current user (newest first)',
+  })
+  @ApiQuery({ name: 'limit', required: false, description: 'Page size (default 20, max 100)' })
+  @ApiQuery({ name: 'cursor', required: false, description: 'createdAt ISO cursor' })
+  decisions(
+    @CurrentUser() user: { id: string },
+    @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string,
+  ) {
+    const parsed = Math.min(100, Math.max(1, limit ? parseInt(limit, 10) : 20));
+    return this.service.listDecisions(user.id, parsed, cursor);
   }
 }

--- a/apps/api-server/src/llm-trades/llm-trades.service.ts
+++ b/apps/api-server/src/llm-trades/llm-trades.service.ts
@@ -163,4 +163,37 @@ export class LlmTradesService {
 
     return { id: order.id, status: 'pending' };
   }
+
+  async listDecisions(userId: string, limit: number, cursor?: string) {
+    const cursorDate = cursor ? new Date(cursor) : undefined;
+    const rows = await this.prisma.llmDecisionLog.findMany({
+      where: {
+        userId,
+        ...(cursorDate ? { createdAt: { lt: cursorDate } } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit + 1,
+      include: {
+        order: {
+          select: {
+            id: true,
+            status: true,
+            symbol: true,
+            side: true,
+            entryPrice: true,
+            takeProfitPrice: true,
+            stopLossPrice: true,
+            realizedPnl: true,
+            closedAt: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? items[items.length - 1].createdAt.toISOString() : null;
+    return { items, nextCursor };
+  }
 }

--- a/apps/api-server/src/orders/commands/close-order.command.ts
+++ b/apps/api-server/src/orders/commands/close-order.command.ts
@@ -1,0 +1,6 @@
+export class CloseOrderCommand {
+  constructor(
+    public readonly userId: string,
+    public readonly orderId: string,
+  ) {}
+}

--- a/apps/api-server/src/orders/commands/close-order.handler.test.ts
+++ b/apps/api-server/src/orders/commands/close-order.handler.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('kafkajs', () => {
+  class FakeKafka {
+    producer() {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        send: mockSend,
+      };
+    }
+  }
+  return { Kafka: FakeKafka };
+});
+
+import { CloseOrderHandler } from './close-order.handler';
+import { CloseOrderCommand } from './close-order.command';
+
+const mockPrisma = { order: { findFirst: vi.fn() } };
+
+describe('CloseOrderHandler', () => {
+  let handler: CloseOrderHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handler = new CloseOrderHandler(mockPrisma as never);
+  });
+
+  it('찾을 수 없으면 NotFoundException', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue(null);
+    await expect(handler.execute(new CloseOrderCommand('u', 'x'))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('이미 닫힌 주문은 거부', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      id: 'o',
+      mode: 'real',
+      status: 'filled',
+      closedAt: new Date(),
+      exchangeKeyId: 'k',
+    });
+    await expect(handler.execute(new CloseOrderCommand('u', 'o'))).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('체결 안된 주문은 거부', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      id: 'o',
+      mode: 'real',
+      status: 'pending',
+      closedAt: null,
+      exchangeKeyId: 'k',
+    });
+    await expect(handler.execute(new CloseOrderCommand('u', 'o'))).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('체결된 실거래 포지션은 Kafka 이벤트를 발행한다', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      id: 'o',
+      mode: 'real',
+      status: 'filled',
+      closedAt: null,
+      exchangeKeyId: 'k',
+    });
+
+    const result = await handler.execute(new CloseOrderCommand('u', 'o'));
+    expect(result).toEqual({ id: 'o', status: 'pending' });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const call = mockSend.mock.calls[0][0];
+    expect(call.topic).toBe('trading.order.close-requested');
+    const payload = JSON.parse(call.messages[0].value);
+    expect(payload.userId).toBe('u');
+    expect(payload.dbOrderId).toBe('o');
+    expect(payload.requestId).toBeTruthy();
+  });
+});

--- a/apps/api-server/src/orders/commands/close-order.handler.ts
+++ b/apps/api-server/src/orders/commands/close-order.handler.ts
@@ -1,0 +1,80 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { Kafka, Producer } from 'kafkajs';
+import { randomUUID } from 'crypto';
+import { KAFKA_TOPICS } from '@coin/kafka-contracts';
+import type { OrderCloseRequestedEvent } from '@coin/kafka-contracts';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CloseOrderCommand } from './close-order.command';
+
+@Injectable()
+@CommandHandler(CloseOrderCommand)
+export class CloseOrderHandler
+  implements ICommandHandler<CloseOrderCommand>, OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new Logger(CloseOrderHandler.name);
+  private kafka: Kafka;
+  private producer: Producer;
+  private connected = false;
+
+  constructor(private readonly prisma: PrismaService) {
+    this.kafka = new Kafka({
+      clientId: 'api-orders-close',
+      brokers: (process.env.KAFKA_BROKERS || 'localhost:9092').split(','),
+    });
+    this.producer = this.kafka.producer();
+  }
+
+  async onModuleInit() {
+    await this.producer.connect();
+    this.connected = true;
+  }
+
+  async onModuleDestroy() {
+    if (this.connected) await this.producer.disconnect();
+  }
+
+  async execute(command: CloseOrderCommand) {
+    const { userId, orderId } = command;
+
+    const order = await this.prisma.order.findFirst({
+      where: { id: orderId, userId },
+    });
+    if (!order) throw new NotFoundException('Order not found');
+
+    if (order.mode !== 'real') {
+      throw new BadRequestException('Only real-mode positions can be manually closed');
+    }
+    if (order.status !== 'filled') {
+      throw new BadRequestException(`Cannot close order with status: ${order.status}`);
+    }
+    if (order.closedAt) {
+      throw new BadRequestException('Position is already closed');
+    }
+    if (!order.exchangeKeyId) {
+      throw new BadRequestException('Order missing exchange key — cannot close');
+    }
+
+    const requestId = randomUUID();
+    const event: OrderCloseRequestedEvent = {
+      requestId,
+      userId,
+      dbOrderId: orderId,
+    };
+
+    await this.producer.send({
+      topic: KAFKA_TOPICS.TRADING_ORDER_CLOSE_REQUESTED,
+      messages: [{ key: userId, value: JSON.stringify(event) }],
+    });
+
+    this.logger.log(`Close requested: ${orderId} (requestId=${requestId})`);
+    return { id: orderId, status: 'pending' };
+  }
+}

--- a/apps/api-server/src/orders/commands/index.ts
+++ b/apps/api-server/src/orders/commands/index.ts
@@ -1,7 +1,9 @@
 import { CreateOrderHandler } from './create-order.handler';
 import { CancelOrderHandler } from './cancel-order.handler';
+import { CloseOrderHandler } from './close-order.handler';
 
-export const OrderCommandHandlers = [CreateOrderHandler, CancelOrderHandler];
+export const OrderCommandHandlers = [CreateOrderHandler, CancelOrderHandler, CloseOrderHandler];
 
 export { CreateOrderCommand } from './create-order.command';
 export { CancelOrderCommand } from './cancel-order.command';
+export { CloseOrderCommand } from './close-order.command';

--- a/apps/api-server/src/orders/orders.controller.ts
+++ b/apps/api-server/src/orders/orders.controller.ts
@@ -19,7 +19,7 @@ import {
 } from '@nestjs/swagger';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
-import { CreateOrderCommand, CancelOrderCommand } from './commands';
+import { CreateOrderCommand, CancelOrderCommand, CloseOrderCommand } from './commands';
 import { GetOrdersQuery, GetOrderQuery } from './queries';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { OrderResponse, OrderListResponse } from './dto/order-response.dto';
@@ -134,5 +134,21 @@ export class OrdersController {
   @ApiParam({ name: 'id', description: '주문 ID' })
   async cancel(@CurrentUser() user: User, @Param('id') id: string) {
     return this.commandBus.execute(new CancelOrderCommand(user.id, id));
+  }
+
+  @Post(':id/close')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({
+    summary: '체결된 실거래 포지션을 시장가 reduceOnly로 수동 종료',
+    description:
+      '체결된 실거래(real) 주문에 대해 reduceOnly MARKET 주문으로 포지션을 수동 종료합니다. Kafka 이벤트가 발행되며 worker가 거래소 종료를 처리합니다.',
+  })
+  @ApiResponse({ status: 202, description: '종료 요청 접수' })
+  @ApiResponse({ status: 400, description: '이미 종료된 주문이거나 실거래가 아님' })
+  @ApiResponse({ status: 401, description: '인증 필요' })
+  @ApiResponse({ status: 404, description: '주문을 찾을 수 없음' })
+  @ApiParam({ name: 'id', description: '주문 ID' })
+  async close(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.commandBus.execute(new CloseOrderCommand(user.id, id));
   }
 }

--- a/apps/api-server/src/orders/queries/get-order.handler.test.ts
+++ b/apps/api-server/src/orders/queries/get-order.handler.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NotFoundException } from '@nestjs/common';
+
+const { mockRedisGet } = vi.hoisted(() => ({ mockRedisGet: vi.fn() }));
+
+vi.mock('ioredis', () => {
+  class FakeRedis {
+    get = mockRedisGet;
+  }
+  return { default: FakeRedis };
+});
+
 import { GetOrderHandler } from './get-order.handler';
 import { GetOrderQuery } from './get-order.query';
 
@@ -13,19 +23,66 @@ describe('GetOrderHandler', () => {
     handler = new GetOrderHandler(mockPrisma as never);
   });
 
-  it('주문을 반환해야 한다', async () => {
-    const order = { id: 'order-1', userId: 'user-1', symbol: 'KRW-BTC' };
+  it('주문 + 결정 + 마크 가격 + 미실현 PnL을 반환한다', async () => {
+    const order = {
+      id: 'order-1',
+      userId: 'user-1',
+      exchange: 'binance',
+      symbol: 'BTCUSDT',
+      side: 'long',
+      status: 'filled',
+      filledQuantity: '0.1',
+      entryPrice: '60000',
+      closedAt: null,
+      llmDecision: { id: 'd-1', model: 'opus' },
+      exchangeKey: { network: 'testnet' },
+    };
     mockPrisma.order.findFirst.mockResolvedValue(order);
+    mockRedisGet.mockResolvedValue(JSON.stringify({ price: '61000' }));
 
     const result = await handler.execute(new GetOrderQuery('user-1', 'order-1'));
-    expect(result).toEqual(order);
+
+    expect(result.order).toEqual(order);
+    expect(result.decision).toEqual(order.llmDecision);
+    expect(result.network).toBe('testnet');
+    expect(result.markPrice).toBe(61000);
+    // (61000 - 60000) * 0.1 * (long → +1) = 100
+    expect(result.unrealizedPnl).toBe(100);
   });
 
-  it('찾을 수 없으면 NotFoundException을 던져야 한다', async () => {
-    mockPrisma.order.findFirst.mockResolvedValue(null);
+  it('short 포지션의 미실현 PnL은 부호가 반대다', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      id: 'o',
+      side: 'short',
+      filledQuantity: '0.1',
+      entryPrice: '60000',
+      closedAt: null,
+      llmDecision: null,
+      exchangeKey: null,
+    });
+    mockRedisGet.mockResolvedValue(JSON.stringify({ price: '59000' }));
 
-    await expect(handler.execute(new GetOrderQuery('user-1', 'non-existent'))).rejects.toThrow(
-      NotFoundException,
-    );
+    const result = await handler.execute(new GetOrderQuery('u', 'o'));
+    expect(result.unrealizedPnl).toBe(100);
+  });
+
+  it('이미 닫힌 주문은 미실현 PnL이 null', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue({
+      side: 'long',
+      filledQuantity: '0.1',
+      entryPrice: '60000',
+      closedAt: new Date(),
+      llmDecision: null,
+      exchangeKey: null,
+    });
+    mockRedisGet.mockResolvedValue(JSON.stringify({ price: '61000' }));
+
+    const result = await handler.execute(new GetOrderQuery('u', 'o'));
+    expect(result.unrealizedPnl).toBeNull();
+  });
+
+  it('찾을 수 없으면 NotFoundException을 던진다', async () => {
+    mockPrisma.order.findFirst.mockResolvedValue(null);
+    await expect(handler.execute(new GetOrderQuery('u', 'x'))).rejects.toThrow(NotFoundException);
   });
 });

--- a/apps/api-server/src/orders/queries/get-order.handler.ts
+++ b/apps/api-server/src/orders/queries/get-order.handler.ts
@@ -1,17 +1,67 @@
-import { NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import Redis from 'ioredis';
+import type { Ticker } from '@coin/types';
 import { PrismaService } from '../../prisma/prisma.service';
 import { GetOrderQuery } from './get-order.query';
 
+@Injectable()
 @QueryHandler(GetOrderQuery)
 export class GetOrderHandler implements IQueryHandler<GetOrderQuery> {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly redis: Redis;
+
+  constructor(private readonly prisma: PrismaService) {
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+  }
 
   async execute(query: GetOrderQuery) {
     const order = await this.prisma.order.findFirst({
       where: { id: query.orderId, userId: query.userId },
+      include: {
+        llmDecision: true,
+        exchangeKey: { select: { network: true } },
+      },
     });
     if (!order) throw new NotFoundException('Order not found');
-    return order;
+
+    const markPrice = await this.fetchMarkPrice(order.exchange, order.symbol);
+    const unrealizedPnl = this.computeUnrealizedPnl(order, markPrice);
+
+    return {
+      order,
+      decision: order.llmDecision,
+      network: order.exchangeKey?.network ?? 'mainnet',
+      markPrice,
+      unrealizedPnl,
+    };
+  }
+
+  private async fetchMarkPrice(exchange: string, symbol: string): Promise<number | null> {
+    const data = await this.redis.get(`ticker:${exchange}:${symbol}`);
+    if (!data) return null;
+    const ticker: Ticker = JSON.parse(data);
+    const n = Number(ticker.price);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  private computeUnrealizedPnl(
+    order: {
+      side: string;
+      entryPrice: string | null;
+      filledQuantity: string;
+      closedAt: Date | null;
+    },
+    markPrice: number | null,
+  ): number | null {
+    if (order.closedAt) return null;
+    if (markPrice == null) return null;
+    const entry = Number(order.entryPrice ?? 0);
+    const qty = Number(order.filledQuantity ?? 0);
+    if (!entry || !qty) return null;
+    const direction = order.side === 'long' ? 1 : -1;
+    return Math.round((markPrice - entry) * qty * direction * 100) / 100;
   }
 }

--- a/apps/api-server/src/portfolio/dto/portfolio-response.dto.ts
+++ b/apps/api-server/src/portfolio/dto/portfolio-response.dto.ts
@@ -7,6 +7,9 @@ export class PortfolioAssetResponse {
   @ApiProperty({ description: '통화' })
   currency!: string;
 
+  @ApiProperty({ description: '네트워크', enum: ['testnet', 'mainnet'] })
+  network!: 'testnet' | 'mainnet';
+
   @ApiProperty({ description: '수량' })
   quantity!: string;
 
@@ -31,7 +34,22 @@ class DailyPnlItem {
   pnl!: number;
 }
 
+class NetworkBreakdownResponse {
+  @ApiProperty() totalValueKrw!: number;
+  @ApiProperty() realizedPnl!: number;
+  @ApiProperty() unrealizedPnl!: number;
+  @ApiProperty({ type: [DailyPnlItem] }) dailyPnl!: DailyPnlItem[];
+}
+
+class PortfolioByNetworkResponse {
+  @ApiProperty({ type: NetworkBreakdownResponse }) testnet!: NetworkBreakdownResponse;
+  @ApiProperty({ type: NetworkBreakdownResponse }) mainnet!: NetworkBreakdownResponse;
+}
+
 export class PortfolioSummaryResponse {
+  @ApiProperty({ description: '필터된 네트워크', enum: ['testnet', 'mainnet', 'all'] })
+  network!: 'testnet' | 'mainnet' | 'all';
+
   @ApiProperty({ description: '총 자산 가치 (KRW)' })
   totalValueKrw!: number;
 
@@ -44,9 +62,9 @@ export class PortfolioSummaryResponse {
   @ApiProperty({ description: '자산 목록', type: [PortfolioAssetResponse] })
   assets!: PortfolioAssetResponse[];
 
-  @ApiProperty({ description: '일별 P&L', type: [DailyPnlItem] })
+  @ApiProperty({ description: '일별 누적 P&L', type: [DailyPnlItem] })
   dailyPnl!: DailyPnlItem[];
 
-  @ApiProperty({ description: '모드', example: 'all' })
-  mode!: string;
+  @ApiProperty({ description: '네트워크별 분할', type: PortfolioByNetworkResponse })
+  byNetwork!: PortfolioByNetworkResponse;
 }

--- a/apps/api-server/src/portfolio/portfolio.controller.ts
+++ b/apps/api-server/src/portfolio/portfolio.controller.ts
@@ -4,6 +4,7 @@ import { PortfolioSummaryResponse } from './dto/portfolio-response.dto';
 import { QueryBus } from '@nestjs/cqrs';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { GetPortfolioSummaryQuery } from './queries';
+import type { PortfolioNetwork } from './queries/get-portfolio-summary.query';
 import type { User } from '@coin/database';
 
 @ApiTags('Portfolio')
@@ -14,22 +15,22 @@ export class PortfolioController {
 
   @Get('summary')
   @ApiOperation({
-    summary: '모든 거래소의 통합 포트폴리오 요약 조회',
+    summary: '포트폴리오 요약 (네트워크 분리)',
     description:
-      '## 포트폴리오 집계\n\n- **전체(all)**: 실제 거래소 잔고 + 모든 체결 주문 기반 손익\n- **실전(real)**: 실제 거래소 API에서 잔고 조회\n- **모의(paper)**: 모의 주문 이력 기반 가상 잔고 계산\n\n포트폴리오 요약을 조회합니다. 총 자산 가치, 실현/미실현 손익, 자산별 상세 내역을 반환합니다.\n\n- **전체(all)**: 실제 거래소 잔고 + 전체 주문 기반 손익\n- **실전(real)**: 거래소 API에서 실제 잔고 조회\n- **모의(paper)**: 모의 주문 이력 기반 가상 잔고 계산',
+      '실제 거래소 잔고와 체결된 주문 기반의 손익을 반환합니다. `network`로 testnet/mainnet/all 필터링이 가능하며, all 응답에는 `byNetwork` 분할 합계가 포함됩니다.',
   })
   @ApiResponse({ status: 200, description: '포트폴리오 요약 반환', type: PortfolioSummaryResponse })
   @ApiResponse({ status: 401, description: '인증 필요' })
   @ApiQuery({
-    name: 'mode',
+    name: 'network',
     required: false,
-    enum: ['paper', 'real', 'all'],
-    description: '거래 모드 필터',
+    enum: ['testnet', 'mainnet', 'all'],
+    description: '거래 네트워크 필터',
   })
   async getSummary(
     @CurrentUser() user: User,
-    @Query('mode') mode?: 'paper' | 'real' | 'all',
+    @Query('network') network?: PortfolioNetwork,
   ): Promise<unknown> {
-    return this.queryBus.execute(new GetPortfolioSummaryQuery(user.id, mode));
+    return this.queryBus.execute(new GetPortfolioSummaryQuery(user.id, network));
   }
 }

--- a/apps/api-server/src/portfolio/portfolio.service.test.ts
+++ b/apps/api-server/src/portfolio/portfolio.service.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('ioredis', () => {
+  class FakeRedis {
+    get = vi.fn().mockResolvedValue(null);
+  }
+  return { default: FakeRedis };
+});
+
+import { PortfolioService } from './portfolio.service';
+
+const mockKeys = [
+  {
+    id: 'k-test',
+    userId: 'u',
+    exchange: 'binance',
+    network: 'testnet',
+    apiKey: 'enc',
+    secretKey: 'enc',
+  },
+  {
+    id: 'k-main',
+    userId: 'u',
+    exchange: 'binance',
+    network: 'mainnet',
+    apiKey: 'enc',
+    secretKey: 'enc',
+  },
+];
+
+const mockOrders = [
+  {
+    id: 'o-test',
+    userId: 'u',
+    exchange: 'binance',
+    symbol: 'BTCUSDT',
+    side: 'long',
+    status: 'filled',
+    filledQuantity: '0.01',
+    filledPrice: '60000',
+    fee: '0.5',
+    realizedPnl: '5',
+    createdAt: new Date('2026-04-01T00:00:00Z'),
+    exchangeKey: { network: 'testnet' },
+  },
+  {
+    id: 'o-main',
+    userId: 'u',
+    exchange: 'binance',
+    symbol: 'BTCUSDT',
+    side: 'long',
+    status: 'filled',
+    filledQuantity: '0.02',
+    filledPrice: '60000',
+    fee: '1',
+    realizedPnl: '10',
+    createdAt: new Date('2026-04-02T00:00:00Z'),
+    exchangeKey: { network: 'mainnet' },
+  },
+];
+
+const mockPrisma = {
+  exchangeKey: { findMany: vi.fn().mockResolvedValue(mockKeys) },
+  order: { findMany: vi.fn().mockResolvedValue(mockOrders) },
+};
+const mockConfig = { getOrThrow: vi.fn().mockReturnValue('master-key') };
+
+vi.mock('@coin/utils', () => ({
+  decrypt: vi.fn().mockReturnValue('plaintext'),
+}));
+
+vi.mock('@coin/exchange-adapters', () => {
+  class FakeBinanceRest {
+    getBalances = vi.fn().mockResolvedValue([]);
+  }
+  return { BinanceRest: FakeBinanceRest };
+});
+
+describe('PortfolioService.getSummary', () => {
+  let svc: PortfolioService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.exchangeKey.findMany.mockResolvedValue(mockKeys);
+    mockPrisma.order.findMany.mockResolvedValue(mockOrders);
+    svc = new PortfolioService(mockPrisma as never, mockConfig as never);
+  });
+
+  it('network=testnet 은 testnet 합계만 반환한다', async () => {
+    const result = await svc.getSummary('u', 'testnet');
+    expect(result.network).toBe('testnet');
+    expect(result.realizedPnl).toBe(5);
+    expect(result.byNetwork.testnet.realizedPnl).toBe(5);
+    expect(result.byNetwork.mainnet.realizedPnl).toBe(10);
+  });
+
+  it('network=mainnet 은 mainnet 합계만 반환한다', async () => {
+    const result = await svc.getSummary('u', 'mainnet');
+    expect(result.network).toBe('mainnet');
+    expect(result.realizedPnl).toBe(10);
+  });
+
+  it('network=all 은 합계 + byNetwork 분할을 반환한다', async () => {
+    const result = await svc.getSummary('u', 'all');
+    expect(result.network).toBe('all');
+    expect(result.realizedPnl).toBe(15);
+    expect(result.byNetwork.testnet.realizedPnl).toBe(5);
+    expect(result.byNetwork.mainnet.realizedPnl).toBe(10);
+  });
+});

--- a/apps/api-server/src/portfolio/portfolio.service.ts
+++ b/apps/api-server/src/portfolio/portfolio.service.ts
@@ -10,14 +10,24 @@ const REST_ADAPTERS: Record<ExchangeId, () => IExchangeRest> = {
   binance: () => new BinanceRest(),
 };
 
+export type PortfolioNetwork = 'testnet' | 'mainnet' | 'all';
+
 interface PortfolioAsset {
   exchange: string;
   currency: string;
+  network: 'testnet' | 'mainnet';
   quantity: string;
   avgCost: number;
   currentPrice: number;
   valueKrw: number;
   pnl: number;
+}
+
+interface NetworkBreakdown {
+  totalValueKrw: number;
+  realizedPnl: number;
+  unrealizedPnl: number;
+  dailyPnl: Array<{ date: string; pnl: number }>;
 }
 
 function parseBaseCurrency(_exchange: string, symbol: string): string {
@@ -44,133 +54,125 @@ export class PortfolioService {
     });
   }
 
-  async getSummary(userId: string, mode?: 'paper' | 'real' | 'all') {
-    const effectiveMode = mode || 'all';
+  async getSummary(userId: string, network?: PortfolioNetwork) {
+    const effective: PortfolioNetwork = network ?? 'all';
     const masterKey = this.config.getOrThrow<string>('ENCRYPTION_MASTER_KEY');
 
-    // Prefetch filled orders, optionally filtered by mode
-    const orderWhere: { userId: string; status: string; mode?: string } = {
-      userId,
-      status: 'filled',
-    };
-    if (effectiveMode !== 'all') {
-      orderWhere.mode = effectiveMode;
-    }
+    const keys = await this.prisma.exchangeKey.findMany({ where: { userId } });
+    const filteredKeys =
+      effective === 'all' ? keys : keys.filter((k) => (k.network ?? 'mainnet') === effective);
 
-    const allFilledOrders = await this.prisma.order.findMany({
-      where: orderWhere,
+    // Filled orders joined with exchangeKey so we can split by network
+    const filledOrders = await this.prisma.order.findMany({
+      where: { userId, status: 'filled' },
+      include: { exchangeKey: { select: { network: true } } },
       orderBy: { createdAt: 'asc' },
     });
 
-    // Build avg cost map: key = "exchange|currency"
-    const avgCostMap = this.buildAvgCostMap(allFilledOrders);
+    const ordersByNetwork = {
+      testnet: filledOrders.filter((o) => (o.exchangeKey?.network ?? 'mainnet') === 'testnet'),
+      mainnet: filledOrders.filter((o) => (o.exchangeKey?.network ?? 'mainnet') === 'mainnet'),
+    };
 
     const assets: PortfolioAsset[] = [];
+    for (const key of filteredKeys) {
+      try {
+        const credentials: ExchangeCredentials = {
+          apiKey: decrypt(key.apiKey, masterKey),
+          secretKey: decrypt(key.secretKey, masterKey),
+          network: (key.network as 'mainnet' | 'testnet') ?? 'mainnet',
+        };
+        const adapter = REST_ADAPTERS[key.exchange as ExchangeId]();
+        const balances = await adapter.getBalances(credentials);
 
-    if (effectiveMode === 'paper') {
-      // Paper mode: compute virtual balances from order history
-      const virtualBalances = this.computePaperBalances(allFilledOrders);
-      for (const [key, qty] of virtualBalances.entries()) {
-        const [exchange, currency] = key.split('|');
-        if (qty <= 0) continue;
+        const keyNet: 'testnet' | 'mainnet' = (key.network as 'mainnet' | 'testnet') ?? 'mainnet';
+        const avgCostMap = this.buildAvgCostMap(ordersByNetwork[keyNet]);
 
-        const currentPrice = await this.getTickerPrice(exchange, currency);
-        const avgCost = avgCostMap.get(key) ?? 0;
-        const valueKrw = currentPrice * qty;
-        const pnl = avgCost > 0 ? (currentPrice - avgCost) * qty : 0;
+        for (const bal of balances) {
+          const free = parseFloat(bal.free);
+          const locked = parseFloat(bal.locked);
+          const total = free + locked;
+          if (total <= 0) continue;
 
-        assets.push({
-          exchange,
-          currency,
-          quantity: qty.toString(),
-          avgCost,
-          currentPrice,
-          valueKrw,
-          pnl,
-        });
-      }
-    } else {
-      // Real or All mode: fetch from exchange APIs
-      const keys = await this.prisma.exchangeKey.findMany({
-        where: { userId },
-      });
+          const currentPrice = await this.getTickerPrice(key.exchange, bal.currency);
+          const costKey = `${key.exchange}|${bal.currency}`;
+          const avgCost = avgCostMap.get(costKey) ?? 0;
 
-      for (const key of keys) {
-        try {
-          const credentials: ExchangeCredentials = {
-            apiKey: decrypt(key.apiKey, masterKey),
-            secretKey: decrypt(key.secretKey, masterKey),
-          };
-          const adapter = REST_ADAPTERS[key.exchange as ExchangeId]();
-          const balances = await adapter.getBalances(credentials);
+          const valueKrw = currentPrice * total;
+          const pnl = avgCost > 0 ? (currentPrice - avgCost) * total : 0;
 
-          for (const bal of balances) {
-            const free = parseFloat(bal.free);
-            const locked = parseFloat(bal.locked);
-            const total = free + locked;
-            if (total <= 0) continue;
-
-            const currentPrice = await this.getTickerPrice(key.exchange, bal.currency);
-            const costKey = `${key.exchange}|${bal.currency}`;
-            const avgCost = avgCostMap.get(costKey) ?? 0;
-
-            const valueKrw = currentPrice * total;
-            const pnl = avgCost > 0 ? (currentPrice - avgCost) * total : 0;
-
-            assets.push({
-              exchange: key.exchange,
-              currency: bal.currency,
-              quantity: total.toString(),
-              avgCost,
-              currentPrice,
-              valueKrw,
-              pnl,
-            });
-          }
-        } catch (err) {
-          this.logger.warn(`Failed to fetch balances for ${key.exchange}: ${err}`);
+          assets.push({
+            exchange: key.exchange,
+            currency: bal.currency,
+            network: keyNet,
+            quantity: total.toString(),
+            avgCost,
+            currentPrice,
+            valueKrw,
+            pnl,
+          });
         }
+      } catch (err) {
+        this.logger.warn(`Failed to fetch balances for ${key.exchange} (${key.network}): ${err}`);
       }
     }
 
-    // 2. Calculate realized P&L from prefetched orders
-    const realizedPnl = this.calculateRealizedPnl(allFilledOrders, avgCostMap);
+    const breakdownFor = (rows: typeof filledOrders) => {
+      const avgCostMap = this.buildAvgCostMap(rows);
+      const deltas = this.dailyDeltaMap(rows);
+      const summary: NetworkBreakdown = {
+        totalValueKrw: 0,
+        realizedPnl: this.calculateRealizedPnl(rows, avgCostMap),
+        unrealizedPnl: 0,
+        dailyPnl: this.toCumulative(deltas),
+      };
+      return { summary, deltas };
+    };
 
-    // 3. Calculate daily P&L from prefetched orders
-    const dailyPnl = this.calculateDailyPnl(allFilledOrders);
+    const testnetView = breakdownFor(ordersByNetwork.testnet);
+    const mainnetView = breakdownFor(ordersByNetwork.mainnet);
+    const testnetBreakdown = testnetView.summary;
+    const mainnetBreakdown = mainnetView.summary;
+    testnetBreakdown.totalValueKrw = assets
+      .filter((a) => a.network === 'testnet')
+      .reduce((s, a) => s + a.valueKrw, 0);
+    testnetBreakdown.unrealizedPnl = assets
+      .filter((a) => a.network === 'testnet')
+      .reduce((s, a) => s + a.pnl, 0);
+    mainnetBreakdown.totalValueKrw = assets
+      .filter((a) => a.network === 'mainnet')
+      .reduce((s, a) => s + a.valueKrw, 0);
+    mainnetBreakdown.unrealizedPnl = assets
+      .filter((a) => a.network === 'mainnet')
+      .reduce((s, a) => s + a.pnl, 0);
 
-    const totalValueKrw = assets.reduce((sum, a) => sum + a.valueKrw, 0);
-    const unrealizedPnl = assets.reduce((sum, a) => sum + a.pnl, 0);
-
-    return { totalValueKrw, realizedPnl, unrealizedPnl, assets, dailyPnl, mode: effectiveMode };
-  }
-
-  private computePaperBalances(
-    orders: Array<{
-      exchange: string;
-      symbol: string;
-      side: string;
-      filledQuantity: string;
-      filledPrice: string;
-    }>,
-  ): Map<string, number> {
-    const balances = new Map<string, number>();
-
-    for (const order of orders) {
-      const currency = parseBaseCurrency(order.exchange, order.symbol);
-      const key = `${order.exchange}|${currency}`;
-      const qty = parseFloat(order.filledQuantity);
-      if (!Number.isFinite(qty) || qty <= 0) continue;
-
-      const current = balances.get(key) ?? 0;
-      if (order.side === 'buy') {
-        balances.set(key, current + qty);
-      } else {
-        balances.set(key, current - qty);
-      }
+    let totalValueKrw: number;
+    let realizedPnl: number;
+    let unrealizedPnl: number;
+    let dailyPnl: Array<{ date: string; pnl: number }>;
+    if (effective === 'testnet') {
+      ({ totalValueKrw, realizedPnl, unrealizedPnl, dailyPnl } = testnetBreakdown);
+    } else if (effective === 'mainnet') {
+      ({ totalValueKrw, realizedPnl, unrealizedPnl, dailyPnl } = mainnetBreakdown);
+    } else {
+      totalValueKrw = testnetBreakdown.totalValueKrw + mainnetBreakdown.totalValueKrw;
+      realizedPnl = testnetBreakdown.realizedPnl + mainnetBreakdown.realizedPnl;
+      unrealizedPnl = testnetBreakdown.unrealizedPnl + mainnetBreakdown.unrealizedPnl;
+      const merged = new Map<string, number>();
+      for (const [d, v] of testnetView.deltas) merged.set(d, (merged.get(d) ?? 0) + v);
+      for (const [d, v] of mainnetView.deltas) merged.set(d, (merged.get(d) ?? 0) + v);
+      dailyPnl = this.toCumulative(merged);
     }
 
-    return balances;
+    return {
+      network: effective,
+      totalValueKrw,
+      realizedPnl,
+      unrealizedPnl,
+      assets,
+      dailyPnl,
+      byNetwork: { testnet: testnetBreakdown, mainnet: mainnetBreakdown },
+    };
   }
 
   private buildAvgCostMap(
@@ -185,7 +187,9 @@ export class PortfolioService {
     const aggregates = new Map<string, { totalCost: number; totalQty: number }>();
 
     for (const order of orders) {
-      if (order.side !== 'buy') continue;
+      // Treat futures 'long' as buy, 'short' as sell for spot-style cost basis.
+      const isBuy = order.side === 'buy' || order.side === 'long';
+      if (!isBuy) continue;
 
       const qty = parseFloat(order.filledQuantity);
       const price = parseFloat(order.filledPrice);
@@ -231,13 +235,25 @@ export class PortfolioService {
       filledQuantity: string;
       filledPrice: string;
       fee: string;
+      realizedPnl?: string | null;
     }>,
     avgCostMap: Map<string, number>,
   ): number {
     let realized = 0;
 
     for (const order of orders) {
-      if (order.side !== 'sell') continue;
+      // Prefer Binance-reported realizedPnl when present (futures positions
+      // closed via TP/SL/manual). Falls back to spot-style cost basis math.
+      if (order.realizedPnl) {
+        const r = parseFloat(order.realizedPnl);
+        if (Number.isFinite(r) && r !== 0) {
+          realized += r;
+          continue;
+        }
+      }
+
+      const isSell = order.side === 'sell' || order.side === 'short';
+      if (!isSell) continue;
 
       const qty = parseFloat(order.filledQuantity);
       const price = parseFloat(order.filledPrice);
@@ -256,36 +272,48 @@ export class PortfolioService {
     return Math.round(realized * 100) / 100;
   }
 
-  private calculateDailyPnl(
+  private dailyDeltaMap(
     orders: Array<{
       createdAt: Date;
       side: string;
       filledQuantity: string;
       filledPrice: string;
       fee: string;
+      realizedPnl?: string | null;
     }>,
-  ): Array<{ date: string; pnl: number }> {
+  ): Map<string, number> {
     const dailyMap = new Map<string, number>();
 
     for (const order of orders) {
       const date = order.createdAt.toISOString().split('T')[0];
+      const current = dailyMap.get(date) || 0;
+
+      if (order.realizedPnl) {
+        const r = parseFloat(order.realizedPnl);
+        if (Number.isFinite(r) && r !== 0) {
+          dailyMap.set(date, current + r);
+          continue;
+        }
+      }
+
       const qty = parseFloat(order.filledQuantity);
       const price = parseFloat(order.filledPrice);
       const fee = parseFloat(order.fee);
       const value = qty * price;
+      const isSell = order.side === 'sell' || order.side === 'short';
 
-      const current = dailyMap.get(date) || 0;
-      if (order.side === 'sell') {
-        dailyMap.set(date, current + value - fee);
-      } else {
-        dailyMap.set(date, current - value - fee);
-      }
+      dailyMap.set(date, isSell ? current + value - fee : current - value - fee);
     }
+    return dailyMap;
+  }
 
+  private toCumulative(deltas: Map<string, number>): Array<{ date: string; pnl: number }> {
     let cumulative = 0;
-    return Array.from(dailyMap.entries()).map(([date, pnl]) => {
-      cumulative += pnl;
-      return { date, pnl: Math.round(cumulative * 100) / 100 };
-    });
+    return Array.from(deltas.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([date, pnl]) => {
+        cumulative += pnl;
+        return { date, pnl: Math.round(cumulative * 100) / 100 };
+      });
   }
 }

--- a/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.test.ts
+++ b/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.test.ts
@@ -12,18 +12,15 @@ describe('GetPortfolioSummaryHandler', () => {
     handler = new GetPortfolioSummaryHandler(mockPortfolioService as never);
   });
 
-  it('portfolioService.getSummary에 위임해야 한다', async () => {
-    const summary = { totalValue: 1000, assets: [] };
-    mockPortfolioService.getSummary.mockResolvedValue(summary);
+  it('네트워크 필터를 PortfolioService에 위임한다', async () => {
+    mockPortfolioService.getSummary.mockResolvedValue({ network: 'testnet' });
 
-    const result = await handler.execute(new GetPortfolioSummaryQuery('user-1', 'paper'));
-    expect(result).toEqual(summary);
-    expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', 'paper');
+    await handler.execute(new GetPortfolioSummaryQuery('user-1', 'testnet'));
+    expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', 'testnet');
   });
 
-  it('모드가 지정되지 않으면 undefined를 전달해야 한다', async () => {
+  it('네트워크가 지정되지 않으면 undefined를 전달한다', async () => {
     mockPortfolioService.getSummary.mockResolvedValue({});
-
     await handler.execute(new GetPortfolioSummaryQuery('user-1'));
     expect(mockPortfolioService.getSummary).toHaveBeenCalledWith('user-1', undefined);
   });

--- a/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.ts
+++ b/apps/api-server/src/portfolio/queries/get-portfolio-summary.handler.ts
@@ -7,6 +7,6 @@ export class GetPortfolioSummaryHandler implements IQueryHandler<GetPortfolioSum
   constructor(private readonly portfolioService: PortfolioService) {}
 
   async execute(query: GetPortfolioSummaryQuery): Promise<unknown> {
-    return this.portfolioService.getSummary(query.userId, query.mode);
+    return this.portfolioService.getSummary(query.userId, query.network);
   }
 }

--- a/apps/api-server/src/portfolio/queries/get-portfolio-summary.query.ts
+++ b/apps/api-server/src/portfolio/queries/get-portfolio-summary.query.ts
@@ -1,6 +1,8 @@
+export type PortfolioNetwork = 'testnet' | 'mainnet' | 'all';
+
 export class GetPortfolioSummaryQuery {
   constructor(
     public readonly userId: string,
-    public readonly mode?: 'paper' | 'real' | 'all',
+    public readonly network?: PortfolioNetwork,
   ) {}
 }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,20 +1,270 @@
 'use client';
 
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import Link from 'next/link';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronRight, X } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PnlValue } from '@/components/shared/pnl-value';
+import { closePosition, getDashboardSummary, type DashboardSummary } from '@/lib/api-client';
+import { useBaseCurrency } from '@/hooks/use-base-currency';
+import { useExchangeRate } from '@/hooks/use-exchange-rate';
+import { formatCurrency } from '@/lib/utils';
 
 export default function DashboardPage() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['dashboard'],
+    queryFn: getDashboardSummary,
+    refetchInterval: 10_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="max-w-6xl mx-auto p-4 md:p-6 space-y-4">
+        <Skeleton className="h-8 w-40" />
+        <div className="grid md:grid-cols-2 gap-4">
+          <Skeleton className="h-32" />
+          <Skeleton className="h-32" />
+        </div>
+        <Skeleton className="h-48" />
+        <Skeleton className="h-48" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="max-w-6xl mx-auto p-4 md:p-6">
+        <p className="text-muted-foreground">대시보드를 불러올 수 없습니다.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="container mx-auto p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Dashboard</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground">
-            LLM-driven Binance Futures trading is being rebuilt. Check back soon.
-          </p>
-        </CardContent>
-      </Card>
+    <div className="max-w-6xl mx-auto p-4 md:p-6 space-y-6">
+      <h1 className="text-2xl font-bold">대시보드</h1>
+
+      <PnlSection pnl={data.pnl} />
+      <OpenPositionsSection positions={data.openPositions} />
+      <RecentDecisionsSection decisions={data.recentDecisions} />
     </div>
   );
+}
+
+function PnlSection({ pnl }: { pnl: DashboardSummary['pnl'] }) {
+  return (
+    <div className="grid md:grid-cols-2 gap-4">
+      {(['today', 'week'] as const).map((window) => (
+        <Card key={window}>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              {window === 'today' ? '오늘 실현 손익' : '이번주 실현 손익'}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs text-purple-500 mb-1">모의 (Testnet)</p>
+              <p className="text-xl tabular-nums">
+                <PnlValue value={pnl[window].testnet} />
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-orange-500 mb-1">실거래 (Mainnet)</p>
+              <p className="text-xl tabular-nums">
+                <PnlValue value={pnl[window].mainnet} />
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function OpenPositionsSection({ positions }: { positions: DashboardSummary['openPositions'] }) {
+  const queryClient = useQueryClient();
+  const { currency } = useBaseCurrency();
+  const { krwPerUsd } = useExchangeRate();
+
+  const closeMut = useMutation({
+    mutationFn: (id: string) => closePosition(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['dashboard'] }),
+  });
+
+  if (positions.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">활성 포지션</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">현재 열려있는 포지션이 없습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">활성 포지션 ({positions.length})</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-xs text-muted-foreground">
+                <th className="text-left py-2 px-2">심볼</th>
+                <th className="text-left py-2 px-2">방향</th>
+                <th className="text-right py-2 px-2">수량</th>
+                <th className="text-right py-2 px-2">진입가</th>
+                <th className="text-right py-2 px-2">현재가</th>
+                <th className="text-right py-2 px-2">미실현 P&L</th>
+                <th className="text-right py-2 px-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {positions.map((p) => {
+                const entry = p.entryPrice ? Number(p.entryPrice) : null;
+                const entryFmt = entry != null ? formatCurrency(entry, currency, krwPerUsd) : null;
+                const markFmt =
+                  p.markPrice != null ? formatCurrency(p.markPrice, currency, krwPerUsd) : null;
+                const network = p.exchangeKey?.network ?? 'mainnet';
+                return (
+                  <tr key={p.id} className="border-b hover:bg-muted/40">
+                    <td className="py-2 px-2">
+                      <Link
+                        href={`/orders/${p.id}`}
+                        className="font-medium hover:underline inline-flex items-center gap-1"
+                      >
+                        {p.symbol}
+                        <ChevronRight size={12} />
+                      </Link>
+                      <Badge
+                        variant={network === 'mainnet' ? 'orange' : 'purple'}
+                        className="ml-2 text-[10px]"
+                      >
+                        {network === 'mainnet' ? '실거래' : '모의'}
+                      </Badge>
+                    </td>
+                    <td className="py-2 px-2">
+                      <span
+                        className={`uppercase font-medium ${p.side === 'long' ? 'text-green-500' : 'text-red-500'}`}
+                      >
+                        {p.side}
+                      </span>
+                      {p.leverage ? (
+                        <span className="text-xs text-muted-foreground ml-1">{p.leverage}x</span>
+                      ) : null}
+                    </td>
+                    <td className="py-2 px-2 text-right tabular-nums">
+                      {p.filledQuantity || p.quantity}
+                    </td>
+                    <td className="py-2 px-2 text-right tabular-nums">{entryFmt?.main ?? '-'}</td>
+                    <td className="py-2 px-2 text-right tabular-nums">{markFmt?.main ?? '-'}</td>
+                    <td className="py-2 px-2 text-right tabular-nums">
+                      {p.unrealizedPnl != null ? <PnlValue value={p.unrealizedPnl} /> : '-'}
+                    </td>
+                    <td className="py-2 px-2 text-right">
+                      {p.mode === 'real' && (
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={() => closeMut.mutate(p.id)}
+                          disabled={closeMut.isPending}
+                          className="gap-1"
+                        >
+                          <X size={12} />
+                          종료
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentDecisionsSection({ decisions }: { decisions: DashboardSummary['recentDecisions'] }) {
+  if (decisions.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">최근 LLM 결정</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">아직 LLM 시그널 기록이 없습니다.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">최근 LLM 결정 (최대 5건)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {decisions.map((d) => {
+          const outcome = describeOutcome(d.order);
+          return (
+            <div key={d.id} className="border rounded-md p-3 space-y-2">
+              <div className="flex items-center justify-between flex-wrap gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="font-medium">{d.order?.symbol ?? '—'}</span>
+                  <span
+                    className={`uppercase text-sm font-medium ${d.parsedSignal.signal === 'long' ? 'text-green-500' : 'text-red-500'}`}
+                  >
+                    {d.parsedSignal.signal}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    TP {d.parsedSignal.takeProfitPrice} · SL {d.parsedSignal.stopLossPrice}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={outcome.variant}>{outcome.label}</Badge>
+                  {d.order && (
+                    <Link
+                      href={`/orders/${d.order.id}`}
+                      className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center"
+                    >
+                      상세 <ChevronRight size={12} />
+                    </Link>
+                  )}
+                </div>
+              </div>
+              <p className="text-sm text-muted-foreground line-clamp-3">
+                {d.parsedSignal.reasoning}
+              </p>
+              <p className="text-[10px] text-muted-foreground">
+                {new Date(d.createdAt).toLocaleString('ko-KR')} · {d.model} ({d.latencyMs}ms)
+              </p>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+type Outcome = { label: string; variant: 'success' | 'error' | 'info' | 'muted' };
+
+function describeOutcome(order: DashboardSummary['recentDecisions'][number]['order']): Outcome {
+  if (!order) return { label: '미실행', variant: 'muted' };
+  if (order.status === 'pending') return { label: '진행 중', variant: 'info' };
+  if (order.status === 'failed') return { label: '실패', variant: 'error' };
+  if (order.closedAt) {
+    const pnl = Number(order.realizedPnl ?? 0);
+    if (pnl > 0) return { label: 'TP / 익절', variant: 'success' };
+    if (pnl < 0) return { label: 'SL / 손절', variant: 'error' };
+    return { label: '종료', variant: 'muted' };
+  }
+  return { label: '활성', variant: 'info' };
 }

--- a/apps/web/src/app/orders/[id]/page.tsx
+++ b/apps/web/src/app/orders/[id]/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { use } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, X } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { OrderChart } from '@/components/order-chart';
+import { PnlValue } from '@/components/shared/pnl-value';
+import { useBaseCurrency } from '@/hooks/use-base-currency';
+import { useExchangeRate } from '@/hooks/use-exchange-rate';
+import { closePosition, getOrder } from '@/lib/api-client';
+import { formatCurrency } from '@/lib/utils';
+
+export default function OrderDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const queryClient = useQueryClient();
+  const { currency } = useBaseCurrency();
+  const { krwPerUsd } = useExchangeRate();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['order', id],
+    queryFn: () => getOrder(id),
+    refetchInterval: 5000,
+  });
+
+  const closeMut = useMutation({
+    mutationFn: () => closePosition(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['order', id] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="max-w-5xl mx-auto p-4 md:p-6 space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-[400px]" />
+        <div className="grid md:grid-cols-2 gap-4">
+          <Skeleton className="h-40" />
+          <Skeleton className="h-40" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="max-w-5xl mx-auto p-4 md:p-6">
+        <Link
+          href="/activity"
+          className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+        >
+          <ArrowLeft size={14} /> Back
+        </Link>
+        <p className="text-muted-foreground mt-4">주문을 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  const { order, decision, network, markPrice, unrealizedPnl } = data;
+  const isOpen = order.status === 'filled' && !order.closedAt;
+  const isReal = order.mode === 'real';
+  const canClose = isOpen && isReal;
+  const sideColor = order.side === 'long' ? 'text-green-500' : 'text-red-500';
+
+  const entryPrice = order.entryPrice ? Number(order.entryPrice) : null;
+  const tpPrice = order.takeProfitPrice ? Number(order.takeProfitPrice) : null;
+  const slPrice = order.stopLossPrice ? Number(order.stopLossPrice) : null;
+
+  const formatUsd = (n: number | null) => {
+    if (n == null) return '-';
+    const { main, sub } = formatCurrency(n, currency, krwPerUsd);
+    return sub ? (
+      <span className="tabular-nums">
+        {main} <span className="text-xs text-muted-foreground">{sub}</span>
+      </span>
+    ) : (
+      <span className="tabular-nums">{main}</span>
+    );
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-4 md:p-6 space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="space-y-1">
+          <Link
+            href="/activity"
+            className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+          >
+            <ArrowLeft size={14} /> Activity
+          </Link>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold">{order.symbol}</h1>
+            <span className={`text-lg font-semibold uppercase ${sideColor}`}>{order.side}</span>
+            <Badge variant="info">{order.status}</Badge>
+            <Badge variant={network === 'mainnet' ? 'orange' : 'purple'}>
+              {network === 'mainnet' ? '실거래' : '모의'}
+            </Badge>
+            {order.leverage ? <Badge variant="muted">{order.leverage}x</Badge> : null}
+          </div>
+        </div>
+        {canClose && (
+          <Button
+            variant="destructive"
+            onClick={() => closeMut.mutate()}
+            disabled={closeMut.isPending}
+            className="gap-1"
+          >
+            <X size={14} />
+            {closeMut.isPending ? '종료 요청 중...' : '포지션 종료'}
+          </Button>
+        )}
+      </div>
+
+      {closeMut.isError && (
+        <p className="text-sm text-red-500">
+          {closeMut.error instanceof Error ? closeMut.error.message : '종료 요청 실패'}
+        </p>
+      )}
+      {closeMut.isSuccess && (
+        <p className="text-sm text-green-500">종료 요청이 접수되었습니다. 거래소에서 처리 중...</p>
+      )}
+
+      <Card>
+        <CardContent className="pt-4">
+          <OrderChart
+            exchange={order.exchange}
+            symbol={order.symbol}
+            entryPrice={entryPrice}
+            takeProfitPrice={tpPrice}
+            stopLossPrice={slPrice}
+          />
+        </CardContent>
+      </Card>
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">포지션</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm space-y-2">
+            <Row
+              label="수량"
+              value={<span className="tabular-nums">{order.filledQuantity || order.quantity}</span>}
+            />
+            <Row label="진입가" value={formatUsd(entryPrice)} />
+            <Row label="현재가 (Mark)" value={formatUsd(markPrice)} />
+            <Row label="익절 (TP)" value={formatUsd(tpPrice)} />
+            <Row label="손절 (SL)" value={formatUsd(slPrice)} />
+            {order.realizedPnl ? (
+              <Row label="실현 손익" value={<PnlValue value={Number(order.realizedPnl)} />} />
+            ) : (
+              <Row
+                label="미실현 손익"
+                value={unrealizedPnl != null ? <PnlValue value={unrealizedPnl} /> : <span>-</span>}
+              />
+            )}
+            {order.closedAt && (
+              <Row
+                label="종료 시각"
+                value={<span>{new Date(order.closedAt).toLocaleString('ko-KR')}</span>}
+              />
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">LLM 결정</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm space-y-2">
+            {decision ? (
+              <>
+                <Row
+                  label="모델"
+                  value={
+                    <span className="font-mono text-xs">
+                      {decision.model} ({decision.latencyMs}ms)
+                    </span>
+                  }
+                />
+                <Row
+                  label="시그널"
+                  value={
+                    <span
+                      className={`uppercase font-medium ${decision.parsedSignal.signal === 'long' ? 'text-green-500' : 'text-red-500'}`}
+                    >
+                      {decision.parsedSignal.signal}
+                    </span>
+                  }
+                />
+                <div className="pt-2 border-t">
+                  <p className="text-xs text-muted-foreground mb-1">근거</p>
+                  <p className="text-sm whitespace-pre-wrap">{decision.parsedSignal.reasoning}</p>
+                </div>
+              </>
+            ) : (
+              <p className="text-muted-foreground">연결된 LLM 결정이 없습니다.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <span className="text-muted-foreground">{label}</span>
+      {value}
+    </div>
+  );
+}

--- a/apps/web/src/app/portfolio/page.tsx
+++ b/apps/web/src/app/portfolio/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { getPortfolioSummary } from '@/lib/api-client';
+import { getPortfolioSummary, type PortfolioNetwork } from '@/lib/api-client';
 import { useTranslations } from 'next-intl';
 import { formatKrw } from '@/lib/utils';
 import { PnlValue } from '@/components/shared/pnl-value';
@@ -13,16 +13,21 @@ import { AssetTable } from '@/components/portfolio/asset-table';
 import { AssetCardList } from '@/components/portfolio/asset-card-list';
 import { Skeleton, SkeletonCard, SkeletonChart, SkeletonTable } from '@/components/ui/skeleton';
 
-const MODES = ['all', 'real', 'paper'] as const;
-type Mode = (typeof MODES)[number];
+const NETWORKS: PortfolioNetwork[] = ['all', 'testnet', 'mainnet'];
+
+const NETWORK_LABEL: Record<PortfolioNetwork, string> = {
+  all: '전체',
+  testnet: '모의 (Testnet)',
+  mainnet: '실거래 (Mainnet)',
+};
 
 export default function PortfolioPage() {
   const t = useTranslations('portfolio');
-  const [mode, setMode] = useState<Mode>('all');
+  const [network, setNetwork] = useState<PortfolioNetwork>('all');
 
   const { data, isLoading } = useQuery({
-    queryKey: ['portfolio', mode],
-    queryFn: () => getPortfolioSummary(mode),
+    queryKey: ['portfolio', network],
+    queryFn: () => getPortfolioSummary(network),
     staleTime: 60_000,
   });
 
@@ -32,9 +37,9 @@ export default function PortfolioPage() {
         <div className="flex items-center justify-between">
           <Skeleton className="h-8 w-40" />
           <div className="flex gap-2">
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-20" />
           </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -64,36 +69,33 @@ export default function PortfolioPage() {
     );
   }
 
+  const showSplit = network === 'all';
+
   return (
     <div className="max-w-6xl mx-auto p-4 md:p-6 space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <h1 className="text-2xl font-bold">{t('title')}</h1>
         <div className="flex gap-2">
-          {MODES.map((m) => (
+          {NETWORKS.map((n) => (
             <Button
-              key={m}
-              variant={mode === m ? 'default' : 'outline'}
+              key={n}
+              variant={network === n ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setMode(m)}
+              onClick={() => setNetwork(n)}
               className={
-                m === 'paper'
-                  ? mode === m
-                    ? 'bg-purple-600 hover:bg-purple-700'
-                    : ''
-                  : m === 'real'
-                    ? mode === m
-                      ? 'bg-orange-600 hover:bg-orange-700'
-                      : ''
+                n === 'testnet' && network === n
+                  ? 'bg-purple-600 hover:bg-purple-700'
+                  : n === 'mainnet' && network === n
+                    ? 'bg-orange-600 hover:bg-orange-700'
                     : ''
               }
             >
-              {t(m as 'all' | 'real' | 'paper')}
+              {NETWORK_LABEL[n]}
             </Button>
           ))}
         </div>
       </div>
 
-      {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Card>
           <CardContent className="pt-4">
@@ -119,7 +121,55 @@ export default function PortfolioPage() {
         </Card>
       </div>
 
-      {/* P&L Chart */}
+      {showSplit && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium text-purple-500">모의 (Testnet)</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm space-y-1">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t('totalValue')}</span>
+                <span className="tabular-nums">
+                  {formatKrw(data.byNetwork.testnet.totalValueKrw)}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t('realizedPnl')}</span>
+                <PnlValue value={data.byNetwork.testnet.realizedPnl} />
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t('unrealizedPnl')}</span>
+                <PnlValue value={data.byNetwork.testnet.unrealizedPnl} />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-medium text-orange-500">
+                실거래 (Mainnet)
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm space-y-1">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t('totalValue')}</span>
+                <span className="tabular-nums">
+                  {formatKrw(data.byNetwork.mainnet.totalValueKrw)}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t('realizedPnl')}</span>
+                <PnlValue value={data.byNetwork.mainnet.realizedPnl} />
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">{t('unrealizedPnl')}</span>
+                <PnlValue value={data.byNetwork.mainnet.unrealizedPnl} />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
       {data.dailyPnl.length > 0 && (
         <Card>
           <CardHeader>
@@ -131,7 +181,6 @@ export default function PortfolioPage() {
         </Card>
       )}
 
-      {/* Assets — card view on mobile, table on desktop */}
       <div className="md:hidden space-y-2">
         <h2 className="text-base font-semibold">{t('assets')}</h2>
         {data.assets.length > 0 ? (

--- a/apps/web/src/components/base-currency-toggle.tsx
+++ b/apps/web/src/components/base-currency-toggle.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useBaseCurrency } from '@/hooks/use-base-currency';
+
+export function BaseCurrencyToggle() {
+  const { currency, setCurrency } = useBaseCurrency();
+
+  return (
+    <div className="inline-flex rounded-md border bg-card p-0.5 text-xs">
+      {(['KRW', 'USD'] as const).map((c) => (
+        <button
+          key={c}
+          type="button"
+          onClick={() => setCurrency(c)}
+          className={`px-2 py-0.5 rounded ${
+            currency === c
+              ? 'bg-primary text-primary-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          aria-pressed={currency === c}
+          aria-label={`Display values in ${c}`}
+        >
+          {c === 'KRW' ? '₩' : '$'}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav-bar.tsx
+++ b/apps/web/src/components/nav-bar.tsx
@@ -17,6 +17,7 @@ import { Button, buttonVariants } from '@/components/ui/button';
 import { useUser, useLogout } from '@/hooks/use-user';
 import { LanguageSwitcher } from '@/components/language-switcher';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { BaseCurrencyToggle } from '@/components/base-currency-toggle';
 import { isDemo } from '@/lib/demo';
 
 const DEMO_HIDDEN_PATHS = ['/settings'];
@@ -97,6 +98,7 @@ export function NavBar() {
 
         {/* Right section */}
         <div className="flex items-center gap-1.5 shrink-0">
+          <BaseCurrencyToggle />
           <ThemeToggle />
           <LanguageSwitcher />
           {showUserMenu && (

--- a/apps/web/src/components/order-chart.tsx
+++ b/apps/web/src/components/order-chart.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  createChart,
+  ColorType,
+  type IChartApi,
+  type ISeriesApi,
+  type IPriceLine,
+} from 'lightweight-charts';
+import { useCandles } from '@/hooks/use-candles';
+
+const INTERVALS = ['1m', '5m', '15m', '1h', '4h', '1d'] as const;
+
+interface OrderChartProps {
+  exchange: string;
+  symbol: string;
+  entryPrice: number | null;
+  takeProfitPrice: number | null;
+  stopLossPrice: number | null;
+  height?: number;
+}
+
+export function OrderChart({
+  exchange,
+  symbol,
+  entryPrice,
+  takeProfitPrice,
+  stopLossPrice,
+  height = 400,
+}: OrderChartProps) {
+  const [interval, setInterval] = useState('15m');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  const linesRef = useRef<IPriceLine[]>([]);
+
+  const { data: candles, isLoading } = useCandles(exchange, symbol, interval);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const chart = createChart(containerRef.current, {
+      width: containerRef.current.clientWidth,
+      height,
+      layout: {
+        attributionLogo: false,
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: '#9ca3af',
+      },
+      grid: {
+        vertLines: { color: 'rgba(156, 163, 175, 0.1)' },
+        horzLines: { color: 'rgba(156, 163, 175, 0.1)' },
+      },
+      timeScale: { timeVisible: true, secondsVisible: false },
+    });
+
+    const series = chart.addCandlestickSeries({
+      upColor: '#22c55e',
+      downColor: '#ef4444',
+      borderUpColor: '#22c55e',
+      borderDownColor: '#ef4444',
+      wickUpColor: '#22c55e',
+      wickDownColor: '#ef4444',
+    });
+
+    chartRef.current = chart;
+    seriesRef.current = series;
+
+    const handleResize = () => {
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({ width: containerRef.current.clientWidth });
+      }
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      chart.remove();
+      chartRef.current = null;
+      seriesRef.current = null;
+      linesRef.current = [];
+    };
+  }, [height]);
+
+  useEffect(() => {
+    if (!seriesRef.current || !candles) return;
+    seriesRef.current.setData(
+      candles.map((c) => ({
+        time: Math.floor(c.timestamp / 1000) as never,
+        open: Number(c.open),
+        high: Number(c.high),
+        low: Number(c.low),
+        close: Number(c.close),
+      })),
+    );
+  }, [candles]);
+
+  useEffect(() => {
+    const series = seriesRef.current;
+    if (!series) return;
+
+    for (const line of linesRef.current) series.removePriceLine(line);
+    linesRef.current = [];
+
+    const add = (price: number | null, color: string, label: string) => {
+      if (price == null || !Number.isFinite(price)) return;
+      const line = series.createPriceLine({
+        price,
+        color,
+        lineWidth: 1,
+        lineStyle: 2,
+        axisLabelVisible: true,
+        title: label,
+      });
+      linesRef.current.push(line);
+    };
+
+    add(entryPrice, '#3b82f6', 'Entry');
+    add(takeProfitPrice, '#22c55e', 'TP');
+    add(stopLossPrice, '#ef4444', 'SL');
+  }, [entryPrice, takeProfitPrice, stopLossPrice, candles]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 flex-wrap items-center">
+        {INTERVALS.map((iv) => (
+          <button
+            key={iv}
+            type="button"
+            onClick={() => setInterval(iv)}
+            className={`px-2.5 py-1 text-xs rounded-md ${
+              interval === iv
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+            }`}
+          >
+            {iv}
+          </button>
+        ))}
+      </div>
+      <div ref={containerRef} style={{ width: '100%', height }} data-testid="order-chart" />
+      {isLoading && <p className="text-center text-xs text-muted-foreground">Loading candles...</p>}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-portfolio.ts
+++ b/apps/web/src/hooks/use-portfolio.ts
@@ -1,12 +1,12 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { getPortfolioSummary } from '@/lib/api-client';
+import { getPortfolioSummary, type PortfolioNetwork } from '@/lib/api-client';
 
-export function usePortfolio(mode: 'paper' | 'real' | 'all' = 'all') {
+export function usePortfolio(network: PortfolioNetwork = 'all') {
   return useQuery({
-    queryKey: ['portfolio', mode],
-    queryFn: () => getPortfolioSummary(mode),
+    queryKey: ['portfolio', network],
+    queryFn: () => getPortfolioSummary(network),
     staleTime: 60_000,
   });
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -246,6 +246,51 @@ export async function cancelOrder(id: string): Promise<{ id: string; status: str
   return res.json();
 }
 
+export interface OrderDetail {
+  order: OrderItem & {
+    entryPrice: string | null;
+    takeProfitPrice: string | null;
+    stopLossPrice: string | null;
+    realizedPnl: string | null;
+    closedAt: string | null;
+    leverage: number | null;
+    positionSide: string | null;
+  };
+  decision: {
+    id: string;
+    parsedSignal: {
+      signal: 'long' | 'short';
+      takeProfitPrice: string;
+      stopLossPrice: string;
+      reasoning: string;
+    };
+    model: string;
+    latencyMs: number;
+    createdAt: string;
+  } | null;
+  network: 'testnet' | 'mainnet';
+  markPrice: number | null;
+  unrealizedPnl: number | null;
+}
+
+export async function getOrder(id: string): Promise<OrderDetail> {
+  const res = await apiFetch(`/orders/${id}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || 'Failed to fetch order');
+  }
+  return res.json();
+}
+
+export async function closePosition(id: string): Promise<{ id: string; status: string }> {
+  const res = await apiFetch(`/orders/${id}/close`, { method: 'POST' });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || 'Failed to close position');
+  }
+  return res.json();
+}
+
 // --- Notifications ---
 
 export interface NotificationSettingItem {
@@ -273,9 +318,12 @@ export async function updateNotificationSettings(
 
 // --- Portfolio ---
 
+export type PortfolioNetwork = 'testnet' | 'mainnet' | 'all';
+
 export interface PortfolioAsset {
   exchange: string;
   currency: string;
+  network: 'testnet' | 'mainnet';
   quantity: string;
   avgCost: number;
   currentPrice: number;
@@ -283,18 +331,25 @@ export interface PortfolioAsset {
   pnl: number;
 }
 
+export interface NetworkBreakdown {
+  totalValueKrw: number;
+  realizedPnl: number;
+  unrealizedPnl: number;
+  dailyPnl: Array<{ date: string; pnl: number }>;
+}
+
 export interface PortfolioSummary {
+  network: PortfolioNetwork;
   totalValueKrw: number;
   realizedPnl: number;
   unrealizedPnl: number;
   assets: PortfolioAsset[];
   dailyPnl: Array<{ date: string; pnl: number }>;
+  byNetwork: { testnet: NetworkBreakdown; mainnet: NetworkBreakdown };
 }
 
-export async function getPortfolioSummary(
-  mode?: 'paper' | 'real' | 'all',
-): Promise<PortfolioSummary> {
-  const params = mode ? `?mode=${mode}` : '';
+export async function getPortfolioSummary(network?: PortfolioNetwork): Promise<PortfolioSummary> {
+  const params = network ? `?network=${network}` : '';
   const res = await apiFetch(`/portfolio/summary${params}`);
   if (!res.ok) throw new Error('Failed to fetch portfolio');
   return res.json();
@@ -422,6 +477,56 @@ export async function requestSignal(input: {
     const body = await res.json().catch(() => ({}));
     throw new Error(body.message || 'Failed to request signal');
   }
+  return res.json();
+}
+
+export interface LlmDecisionItem {
+  id: string;
+  parsedSignal: {
+    signal: 'long' | 'short';
+    takeProfitPrice: string;
+    stopLossPrice: string;
+    reasoning: string;
+  };
+  model: string;
+  latencyMs: number;
+  createdAt: string;
+  order: {
+    id: string;
+    status: string;
+    symbol: string;
+    side: string;
+    entryPrice: string | null;
+    takeProfitPrice: string | null;
+    stopLossPrice: string | null;
+    realizedPnl: string | null;
+    closedAt: string | null;
+    createdAt: string;
+  } | null;
+}
+
+export interface DashboardSummary {
+  pnl: {
+    today: { testnet: number; mainnet: number };
+    week: { testnet: number; mainnet: number };
+  };
+  openPositions: Array<
+    OrderItem & {
+      entryPrice: string | null;
+      takeProfitPrice: string | null;
+      stopLossPrice: string | null;
+      leverage: number | null;
+      markPrice: number | null;
+      unrealizedPnl: number | null;
+      exchangeKey: { network: 'testnet' | 'mainnet' } | null;
+    }
+  >;
+  recentDecisions: LlmDecisionItem[];
+}
+
+export async function getDashboardSummary(): Promise<DashboardSummary> {
+  const res = await apiFetch('/dashboard/summary');
+  if (!res.ok) throw new Error('Failed to fetch dashboard');
   return res.json();
 }
 

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cn, formatPrice, formatKrw, formatVolume } from './utils';
+import { cn, formatPrice, formatKrw, formatVolume, formatCurrency } from './utils';
 
 describe('cn', () => {
   it('클래스 이름을 병합해야 한다', () => {
@@ -60,5 +60,24 @@ describe('formatVolume', () => {
 
   it('1000 미만이면 소수점 2자리로 표시해야 한다', () => {
     expect(formatVolume('42.5')).toBe('42.50');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('KRW 모드에서 main=원 표기, sub=달러 표기', () => {
+    const { main, sub } = formatCurrency(100, 'KRW', 1300);
+    expect(main).toContain('₩');
+    expect(sub).toContain('$');
+  });
+
+  it('USD 모드에서 main=달러 표기, sub=원 표기', () => {
+    const { main, sub } = formatCurrency(100, 'USD', 1300);
+    expect(main).toContain('$');
+    expect(sub).toContain('₩');
+  });
+
+  it('환율 0이면 sub은 null', () => {
+    const { sub } = formatCurrency(100, 'KRW', 0);
+    expect(sub).toBeNull();
   });
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -25,3 +25,33 @@ export function formatVolume(volume: string): string {
   if (num >= 1_000) return `${(num / 1_000).toFixed(2)}K`;
   return num.toFixed(2);
 }
+
+export type BaseCurrency = 'KRW' | 'USD';
+
+/**
+ * Render a USD-denominated value with a sub-label in the alternate currency.
+ * Returns the main string only (no sub) when the rate is unknown.
+ */
+export function formatCurrency(
+  usd: number,
+  baseCurrency: BaseCurrency,
+  krwPerUsd: number,
+): { main: string; sub: string | null } {
+  if (!Number.isFinite(usd)) return { main: '-', sub: null };
+  const usdStr = usd.toLocaleString('ko-KR', {
+    maximumFractionDigits: Math.abs(usd) >= 1 ? 2 : 6,
+  });
+  if (!krwPerUsd) return { main: `$${usdStr}`, sub: null };
+
+  if (baseCurrency === 'KRW') {
+    const krw = usd * krwPerUsd;
+    return {
+      main: `${krw < 0 ? '-' : ''}₩${formatKrw(Math.abs(krw))}`,
+      sub: `$${usdStr}`,
+    };
+  }
+  return {
+    main: `${usd < 0 ? '-' : ''}$${Math.abs(usd).toLocaleString('ko-KR', { maximumFractionDigits: Math.abs(usd) >= 1 ? 2 : 6 })}`,
+    sub: `₩${formatKrw(usd * krwPerUsd)}`,
+  };
+}

--- a/apps/web/src/mocks/data/portfolio.ts
+++ b/apps/web/src/mocks/data/portfolio.ts
@@ -1,6 +1,14 @@
 import type { PortfolioSummary } from '@/lib/api-client';
 
+const emptyBreakdown = {
+  totalValueKrw: 0,
+  realizedPnl: 0,
+  unrealizedPnl: 0,
+  dailyPnl: [] as Array<{ date: string; pnl: number }>,
+};
+
 export const demoPortfolio: PortfolioSummary = {
+  network: 'all',
   totalValueKrw: 15_420_000,
   realizedPnl: 2_850_000,
   unrealizedPnl: 680_000,
@@ -8,6 +16,7 @@ export const demoPortfolio: PortfolioSummary = {
     {
       exchange: 'binance',
       currency: 'BTC',
+      network: 'mainnet',
       quantity: '0.007',
       avgCost: 134_250_000,
       currentPrice: 136_500_000,
@@ -17,6 +26,7 @@ export const demoPortfolio: PortfolioSummary = {
     {
       exchange: 'binance',
       currency: 'ETH',
+      network: 'mainnet',
       quantity: '0.1',
       avgCost: 5_200_000,
       currentPrice: 5_350_000,
@@ -26,6 +36,7 @@ export const demoPortfolio: PortfolioSummary = {
     {
       exchange: 'binance',
       currency: 'SOL',
+      network: 'testnet',
       quantity: '5',
       avgCost: 220_000,
       currentPrice: 228_000,
@@ -35,6 +46,7 @@ export const demoPortfolio: PortfolioSummary = {
     {
       exchange: 'binance',
       currency: 'XRP',
+      network: 'mainnet',
       quantity: '500',
       avgCost: 3_150,
       currentPrice: 3_280,
@@ -44,6 +56,7 @@ export const demoPortfolio: PortfolioSummary = {
     {
       exchange: 'binance',
       currency: 'USDT',
+      network: 'mainnet',
       quantity: '5000',
       avgCost: 1,
       currentPrice: 1,
@@ -60,4 +73,13 @@ export const demoPortfolio: PortfolioSummary = {
     { date: '2026-04-05', pnl: 990_000 },
     { date: '2026-04-06', pnl: 1_400_000 },
   ],
+  byNetwork: {
+    testnet: { ...emptyBreakdown, totalValueKrw: 1_140_000, unrealizedPnl: 40_000 },
+    mainnet: {
+      ...emptyBreakdown,
+      totalValueKrw: 14_280_500,
+      realizedPnl: 2_850_000,
+      unrealizedPnl: 640_000,
+    },
+  },
 };

--- a/apps/worker-service/src/orders/orders.service.ts
+++ b/apps/worker-service/src/orders/orders.service.ts
@@ -2,10 +2,15 @@ import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/commo
 import { Kafka, Consumer, Producer } from 'kafkajs';
 import Redis from 'ioredis';
 import { KAFKA_TOPICS } from '@coin/kafka-contracts';
-import type { OrderRequestedEvent, OrderResultEvent } from '@coin/kafka-contracts';
+import type {
+  OrderRequestedEvent,
+  OrderResultEvent,
+  OrderCloseRequestedEvent,
+} from '@coin/kafka-contracts';
 import type { OrderResult } from '@coin/types';
 import { PrismaService } from '../prisma/prisma.service';
 import { executeRealOrderSaga } from './sagas/real-execution-steps';
+import { executeClosePositionSaga } from './sagas/close-position-saga';
 import { RiskGuardService } from '../risk/risk-guard.service';
 
 @Injectable()
@@ -43,14 +48,23 @@ export class OrdersService implements OnModuleInit, OnModuleDestroy {
         topic: KAFKA_TOPICS.TRADING_ORDER_REQUESTED,
         fromBeginning: false,
       });
+      await this.consumer.subscribe({
+        topic: KAFKA_TOPICS.TRADING_ORDER_CLOSE_REQUESTED,
+        fromBeginning: false,
+      });
       this.logger.log('Order consumer subscribed');
 
       await this.consumer.run({
-        eachMessage: async ({ message }) => {
+        eachMessage: async ({ topic, message }) => {
           try {
-            console.log('[OrdersService] message received');
-            const event: OrderRequestedEvent = JSON.parse(message.value!.toString());
-            await this.handleOrderRequested(event);
+            const raw = message.value!.toString();
+            if (topic === KAFKA_TOPICS.TRADING_ORDER_CLOSE_REQUESTED) {
+              const event: OrderCloseRequestedEvent = JSON.parse(raw);
+              await executeClosePositionSaga(event, this.prisma, this.producer, this.redis);
+            } else {
+              const event: OrderRequestedEvent = JSON.parse(raw);
+              await this.handleOrderRequested(event);
+            }
           } catch (err) {
             console.error('[OrdersService] message processing error:', err);
           }

--- a/apps/worker-service/src/orders/sagas/close-position-saga.test.ts
+++ b/apps/worker-service/src/orders/sagas/close-position-saga.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { closePositionMock, getPositionMock } = vi.hoisted(() => ({
+  closePositionMock: vi.fn(),
+  getPositionMock: vi.fn(),
+}));
+
+vi.mock('@coin/exchange-adapters', () => {
+  class FakeBinanceRest {
+    closePosition = closePositionMock;
+    getPosition = getPositionMock;
+  }
+  return { BinanceRest: FakeBinanceRest };
+});
+
+vi.mock('@coin/utils', () => ({
+  decrypt: vi.fn().mockReturnValue('plain'),
+}));
+
+import { executeClosePositionSaga } from './close-position-saga';
+
+describe('executeClosePositionSaga', () => {
+  const order = {
+    id: 'o-1',
+    userId: 'u',
+    exchange: 'binance',
+    symbol: 'BTCUSDT',
+    side: 'long',
+    status: 'filled',
+    closedAt: null,
+    exchangeKeyId: 'k',
+    quantity: '0.01',
+    filledQuantity: '0.01',
+    entryPrice: '60000',
+  };
+  const exchangeKey = { id: 'k', userId: 'u', apiKey: 'enc', secretKey: 'enc', network: 'mainnet' };
+  const livePosition = {
+    exchange: 'binance',
+    symbol: 'BTCUSDT',
+    side: 'long',
+    quantity: '0.01',
+    entryPrice: '60000',
+    markPrice: '60500',
+    liquidationPrice: '0',
+    leverage: 5,
+    marginType: 'ISOLATED',
+    unrealizedPnl: '5',
+  };
+
+  let prisma: any;
+  let producer: any;
+  let redis: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ENCRYPTION_MASTER_KEY = 'master';
+    prisma = {
+      order: {
+        findFirst: vi.fn().mockResolvedValue(order),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+      exchangeKey: { findFirst: vi.fn().mockResolvedValue(exchangeKey) },
+    };
+    producer = { send: vi.fn().mockResolvedValue(undefined) };
+    redis = { set: vi.fn().mockResolvedValue('OK') };
+    closePositionMock.mockResolvedValue({
+      orderId: 'ex-1',
+      status: 'filled',
+      filledPrice: '61000',
+      filledQuantity: '0.01',
+      symbol: 'BTCUSDT',
+      side: 'long',
+      type: 'market',
+      price: '0',
+      fee: '0',
+      feeCurrency: 'USDT',
+      timestamp: Date.now(),
+    });
+    getPositionMock.mockResolvedValue(livePosition);
+  });
+
+  it('포지션이 살아있으면 closePosition으로 종료한다', async () => {
+    await executeClosePositionSaga(
+      { requestId: 'r1', userId: 'u', dbOrderId: 'o-1' },
+      prisma,
+      producer,
+      redis,
+    );
+
+    expect(closePositionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ network: 'mainnet' }),
+      'BTCUSDT',
+      'long',
+      '0.01',
+    );
+    expect(prisma.order.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'o-1' },
+        data: expect.objectContaining({ status: 'closed' }),
+      }),
+    );
+  });
+
+  it('Binance에 포지션이 이미 없으면 closePosition을 부르지 않고 DB만 동기화한다 (TP/SL 사후 처리)', async () => {
+    getPositionMock.mockResolvedValue(null);
+    await executeClosePositionSaga(
+      { requestId: 'r4', userId: 'u', dbOrderId: 'o-1' },
+      prisma,
+      producer,
+      redis,
+    );
+    expect(closePositionMock).not.toHaveBeenCalled();
+    expect(prisma.order.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'closed' }),
+      }),
+    );
+  });
+
+  it('closePosition이 -2022 reduceOnly rejection을 던지면 DB만 동기화한다', async () => {
+    closePositionMock.mockRejectedValue(
+      new Error('Binance error -2022 ReduceOnly Order is rejected'),
+    );
+    await executeClosePositionSaga(
+      { requestId: 'r5', userId: 'u', dbOrderId: 'o-1' },
+      prisma,
+      producer,
+      redis,
+    );
+    expect(prisma.order.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'closed' }),
+      }),
+    );
+  });
+
+  it('이미 닫힌 주문은 closePosition을 호출하지 않는다', async () => {
+    prisma.order.findFirst.mockResolvedValue({ ...order, closedAt: new Date() });
+    await executeClosePositionSaga(
+      { requestId: 'r2', userId: 'u', dbOrderId: 'o-1' },
+      prisma,
+      producer,
+      redis,
+    );
+    expect(closePositionMock).not.toHaveBeenCalled();
+    expect(prisma.order.update).not.toHaveBeenCalled();
+  });
+
+  it('중복 requestId 잠금이 잡히면 노옵', async () => {
+    redis.set.mockResolvedValue(null);
+    await executeClosePositionSaga(
+      { requestId: 'r3', userId: 'u', dbOrderId: 'o-1' },
+      prisma,
+      producer,
+      redis,
+    );
+    expect(prisma.order.findFirst).not.toHaveBeenCalled();
+    expect(closePositionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker-service/src/orders/sagas/close-position-saga.ts
+++ b/apps/worker-service/src/orders/sagas/close-position-saga.ts
@@ -1,0 +1,205 @@
+import { Logger } from '@nestjs/common';
+import { Producer } from 'kafkajs';
+import Redis from 'ioredis';
+import { KAFKA_TOPICS } from '@coin/kafka-contracts';
+import type {
+  OrderCloseRequestedEvent,
+  OrderResultEvent,
+  NotificationEvent,
+} from '@coin/kafka-contracts';
+import type { ExchangeId, ExchangeCredentials, PositionSide } from '@coin/types';
+import { BinanceRest, IExchangeRest } from '@coin/exchange-adapters';
+import { decrypt } from '@coin/utils';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const REST_ADAPTERS: Record<ExchangeId, () => IExchangeRest> = {
+  binance: () => new BinanceRest(),
+};
+
+// Binance error codes that mean "position no longer exists" — TP/SL already fired,
+// liquidation, or another reduceOnly already drained it. In all of these cases the
+// physical position is gone and the right action is to mark our order closed.
+const POSITION_GONE_CODES = ['-2022', '-4046', '-2023', '-4045'];
+
+function isPositionGoneError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return POSITION_GONE_CODES.some((c) => err.message.includes(c));
+}
+
+export async function executeClosePositionSaga(
+  event: OrderCloseRequestedEvent,
+  prisma: PrismaService,
+  producer: Producer,
+  redis: Redis,
+): Promise<void> {
+  const logger = new Logger('ClosePositionSaga');
+  const lockKey = `saga:close-lock:${event.requestId}`;
+  const acquired = await redis.set(lockKey, '1', 'EX', 60, 'NX');
+  if (!acquired) {
+    logger.log(`Duplicate close request: ${event.requestId}`);
+    return;
+  }
+
+  const order = await prisma.order.findFirst({
+    where: { id: event.dbOrderId, userId: event.userId },
+  });
+  if (!order) {
+    logger.warn(`Order not found for close: ${event.dbOrderId}`);
+    return;
+  }
+  if (order.closedAt) {
+    logger.warn(`Order already closed: ${event.dbOrderId}`);
+    return;
+  }
+  if (!order.exchangeKeyId) {
+    logger.error(`Order ${event.dbOrderId} has no exchangeKeyId; cannot close`);
+    return;
+  }
+
+  const exchangeKey = await prisma.exchangeKey.findFirst({
+    where: { id: order.exchangeKeyId, userId: event.userId },
+  });
+  if (!exchangeKey) {
+    logger.error(`Exchange key not found for close: ${order.exchangeKeyId}`);
+    return;
+  }
+
+  const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+  if (!masterKey) throw new Error('ENCRYPTION_MASTER_KEY not configured');
+
+  const credentials: ExchangeCredentials = {
+    apiKey: decrypt(exchangeKey.apiKey, masterKey),
+    secretKey: decrypt(exchangeKey.secretKey, masterKey),
+    network: (exchangeKey.network as 'mainnet' | 'testnet') ?? 'mainnet',
+  };
+
+  const adapter = REST_ADAPTERS[order.exchange as ExchangeId]();
+  const side = order.side as PositionSide;
+  const quantity = order.filledQuantity || order.quantity;
+
+  // 1. If the position is already gone on Binance (TP/SL fired, liquidation,
+  //    or a previous close request succeeded), just reconcile our DB and stop.
+  const livePosBefore = await adapter.getPosition(credentials, order.symbol).catch((e) => {
+    logger.warn(`getPosition pre-check failed: ${e}`);
+    return null;
+  });
+  if (!livePosBefore) {
+    logger.warn(`Position already gone on exchange — reconciling order ${order.id}`);
+    await markOrderClosed(prisma, order.id, null);
+    await emitClosedEvents(
+      producer,
+      event,
+      order,
+      side,
+      quantity,
+      null,
+      '포지션 종료 (이미 닫혀있던 포지션 동기화)',
+    );
+    return;
+  }
+
+  let closeResult: Awaited<ReturnType<typeof adapter.closePosition>> | null = null;
+  try {
+    closeResult = await adapter.closePosition(credentials, order.symbol, side, quantity);
+    logger.log(
+      `Close placed: ${order.id} → exchangeOrderId=${closeResult.orderId} status=${closeResult.status}`,
+    );
+  } catch (err) {
+    if (isPositionGoneError(err)) {
+      logger.warn(`Close request rejected (position gone): ${err}. Reconciling.`);
+      await markOrderClosed(prisma, order.id, null);
+      await emitClosedEvents(
+        producer,
+        event,
+        order,
+        side,
+        quantity,
+        null,
+        '포지션 종료 (거래소에 포지션 없음)',
+      );
+      return;
+    }
+    logger.error(`Close failed for ${order.id}: ${err}`);
+    await producer.send({
+      topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+      messages: [
+        {
+          key: event.userId,
+          value: JSON.stringify({
+            userId: event.userId,
+            type: 'order_failed',
+            title: `포지션 종료 실패 | ${order.exchange.toUpperCase()} ${order.symbol}`,
+            message: String(err instanceof Error ? err.message : err),
+          } satisfies NotificationEvent),
+        },
+      ],
+    });
+    throw err;
+  }
+
+  // 2. Estimate realizedPnl from entry vs close fill (Binance's MARKET reduceOnly
+  //    fills near-instantly, but avgPrice may be 0 in the immediate response).
+  let realizedPnl: string | null = null;
+  const entry = Number(order.entryPrice ?? 0);
+  const fill = Number(closeResult.filledPrice ?? 0);
+  const qty = Number(quantity);
+  if (entry && fill && qty) {
+    const direction = side === 'long' ? 1 : -1;
+    realizedPnl = String(((fill - entry) * qty * direction).toFixed(8));
+  }
+
+  await markOrderClosed(prisma, order.id, realizedPnl);
+  await emitClosedEvents(
+    producer,
+    event,
+    order,
+    side,
+    quantity,
+    closeResult,
+    `${side.toUpperCase()} ${quantity} 수동 종료 완료`,
+  );
+}
+
+async function markOrderClosed(prisma: PrismaService, orderId: string, realizedPnl: string | null) {
+  await prisma.order.update({
+    where: { id: orderId },
+    data: { status: 'closed', closedAt: new Date(), realizedPnl },
+  });
+}
+
+async function emitClosedEvents(
+  producer: Producer,
+  event: OrderCloseRequestedEvent,
+  order: { exchange: string; symbol: string },
+  side: PositionSide,
+  quantity: string,
+  closeResult: Awaited<ReturnType<BinanceRest['closePosition']>> | null,
+  message: string,
+) {
+  if (closeResult) {
+    const resultEvent: OrderResultEvent = {
+      requestId: event.requestId,
+      userId: event.userId,
+      dbOrderId: event.dbOrderId,
+      result: { ...closeResult },
+      mode: 'real',
+    };
+    await producer.send({
+      topic: KAFKA_TOPICS.TRADING_ORDER_RESULT,
+      messages: [{ key: event.userId, value: JSON.stringify(resultEvent) }],
+    });
+  }
+
+  const notif: NotificationEvent = {
+    userId: event.userId,
+    type: 'order_filled',
+    title: `포지션 종료 | ${order.exchange.toUpperCase()} ${order.symbol}`,
+    message,
+  };
+  await producer.send({
+    topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+    messages: [{ key: event.userId, value: JSON.stringify(notif) }],
+  });
+  void side; // referenced for type discipline; message already encodes it
+  void quantity;
+}

--- a/packages/kafka-contracts/src/events.ts
+++ b/packages/kafka-contracts/src/events.ts
@@ -17,6 +17,12 @@ export interface OrderResultEvent {
   mode: 'paper' | 'real';
 }
 
+export interface OrderCloseRequestedEvent {
+  requestId: string;
+  userId: string;
+  dbOrderId: string;
+}
+
 export interface NotificationEvent {
   userId: string;
   type: 'order_filled' | 'order_failed';

--- a/packages/kafka-contracts/src/topics.ts
+++ b/packages/kafka-contracts/src/topics.ts
@@ -1,6 +1,7 @@
 export const KAFKA_TOPICS = {
   MARKET_TICKER_UPDATED: 'market.ticker.updated',
   TRADING_ORDER_REQUESTED: 'trading.order.requested',
+  TRADING_ORDER_CLOSE_REQUESTED: 'trading.order.close-requested',
   TRADING_ORDER_RESULT: 'trading.order.result',
   TRADING_POSITION_UPDATED: 'trading.position.updated',
   NOTIFICATION_SEND: 'notification.send',


### PR DESCRIPTION
Closes #97.

PR3로 LLM 트레이드 흐름을 사용하기 시작했지만 주변 UI가 미완성이라 일상적인 운영이 어려운 4가지 문제를 한 번에 해결.

## Backend
- **Portfolio**: paper/real/all → testnet/mainnet/all (ExchangeKey.network 기반); `byNetwork` 분할 합계 포함
- **Orders**: `GET /orders/:id` 가 결정/마크가/미실현 PnL까지 hydrate; `POST /orders/:id/close` reduceOnly MARKET 종료
- **Worker close saga**: 거래소 포지션이 이미 사라졌으면(-2022 등) DB만 reconcile
- **LLM trades**: `GET /llm-trades/decisions` 커서 페이지네이션 + 결과 outcome 조인
- **Dashboard**: `/dashboard/summary` 단일 집계 엔드포인트
- **Activity**: 주문 항목 링크 `/orders` → `/orders/:id`

## Frontend
- nav-bar `<BaseCurrencyToggle>` (KRW⇄USD, localStorage)
- `formatCurrency` helper {main, sub} 반환
- `/portfolio` 네트워크 토글, 모의/실거래 분할, 자산 네트워크 배지
- `/orders/[id]` 진입/TP/SL 가격라인 캔들 차트, PnL 패널, 수동 종료, LLM 결정 카드
- `/dashboard` 오늘/이번주 PnL × 네트워크, 활성 포지션 테이블 인라인 종료, 최근 5개 LLM 결정 outcome 배지

## Tests
- 16 api-server + 1 worker + 7 web 슈트 (61 + 3 + 41) 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce network-aware portfolio, order close flow, and a rebuilt dashboard with richer LLM trading insights.

New Features:
- Expose portfolio summaries split by network (testnet/mainnet/all) including per-network breakdowns.
- Add dashboard summary API aggregating today/week PnL by network, open positions with mark prices, and recent LLM decisions.
- Introduce order detail view with charted entry/TP/SL levels, live PnL, manual close action, and attached LLM decision context.
- Add client-side USD/KRW base currency toggle and currency formatting utilities for displaying values in dual currencies.
- Expose cursor-paginated LLM decision listing and order detail API with mark price and unrealized PnL.

Bug Fixes:
- Treat futures long/short sides correctly in cost basis, realized PnL, and daily PnL calculations, preferring exchange-reported realized PnL when available.
- Ensure manual close requests gracefully reconcile already-closed exchange positions instead of failing.

Enhancements:
- Refactor portfolio aggregation to be network-aware and return cumulative daily PnL plus per-network breakdown metadata.
- Wire activity feed order items to deep-link into the new per-order detail page instead of the generic orders list.
- Rebuild the dashboard UI to show network-split PnL, inline-closing of active positions, and recent LLM decision outcomes.
- Extend worker and Kafka contracts to support a dedicated order-close saga handling reduce-only market exits and related notifications.
- Add tests covering portfolio network filtering, order close command behavior, activity links, currency formatting, and enriched order queries.

Tests:
- Add unit tests for portfolio service network filtering and PnL aggregation, order close command validation and Kafka emission, activity link generation, order enrichment handler, and currency formatting.