### PR TITLE
feat: PositionReconciler — auto-detect TP/SL/liquidation fills (#98)

### DIFF
--- a/apps/api-server/src/activity/activity.service.ts
+++ b/apps/api-server/src/activity/activity.service.ts
@@ -14,6 +14,25 @@ export interface ActivityItem {
   createdAt: Date;
 }
 
+function formatCloseReason(reason: string): string {
+  switch (reason) {
+    case 'take_profit':
+      return 'TP 익절';
+    case 'stop_loss':
+      return 'SL 손절';
+    case 'liquidation':
+      return '청산';
+    case 'manual':
+      return '수동 종료';
+    case 'manual_on_exchange':
+      return '거래소에서 종료';
+    case 'reconciled_unknown':
+      return '동기화';
+    default:
+      return reason;
+  }
+}
+
 @Injectable()
 export class ActivityService {
   constructor(private readonly prisma: PrismaService) {}
@@ -44,18 +63,21 @@ export class ActivityService {
       }),
     ]);
 
-    const orderItems: ActivityItem[] = orders.map((o) => ({
-      id: `order-${o.id}`,
-      type: 'order' as const,
-      title: `${o.side.toUpperCase()} ${o.symbol}`,
-      description: `${o.type} ${o.quantity} @ ${o.filledPrice !== '0' ? o.filledPrice : o.price || 'market'} (${o.mode})`,
-      exchange: o.exchange,
-      symbol: o.symbol,
-      status: o.status,
-      side: o.side,
-      link: `/orders/${o.id}`,
-      createdAt: o.createdAt,
-    }));
+    const orderItems: ActivityItem[] = orders.map((o) => {
+      const reasonSuffix = o.closeReason ? ` · ${formatCloseReason(o.closeReason)}` : '';
+      return {
+        id: `order-${o.id}`,
+        type: 'order' as const,
+        title: `${o.side.toUpperCase()} ${o.symbol}`,
+        description: `${o.type} ${o.quantity} @ ${o.filledPrice !== '0' ? o.filledPrice : o.price || 'market'} (${o.mode})${reasonSuffix}`,
+        exchange: o.exchange,
+        symbol: o.symbol,
+        status: o.closedAt ? 'closed' : o.status,
+        side: o.side,
+        link: `/orders/${o.id}`,
+        createdAt: o.createdAt,
+      };
+    });
 
     const loginItems: ActivityItem[] = logins.map((l) => ({
       id: `login-${l.id}`,

--- a/apps/api-server/src/orders/dto/order-response.dto.ts
+++ b/apps/api-server/src/orders/dto/order-response.dto.ts
@@ -45,6 +45,19 @@ export class OrderResponse {
 
   @ApiProperty({ description: '수정일시' })
   updatedAt!: string;
+
+  @ApiPropertyOptional({
+    description: '종료 사유 (TP/SL/청산/수동/거래소-직접 종료/동기화-사유미상)',
+    enum: [
+      'take_profit',
+      'stop_loss',
+      'liquidation',
+      'manual',
+      'manual_on_exchange',
+      'reconciled_unknown',
+    ],
+  })
+  closeReason?: string | null;
 }
 
 export class OrderListResponse {

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -261,9 +261,15 @@ function describeOutcome(order: DashboardSummary['recentDecisions'][number]['ord
   if (order.status === 'pending') return { label: '진행 중', variant: 'info' };
   if (order.status === 'failed') return { label: '실패', variant: 'error' };
   if (order.closedAt) {
+    if (order.closeReason === 'take_profit') return { label: 'TP 익절', variant: 'success' };
+    if (order.closeReason === 'stop_loss') return { label: 'SL 손절', variant: 'error' };
+    if (order.closeReason === 'liquidation') return { label: '청산', variant: 'error' };
+    if (order.closeReason === 'manual') return { label: '수동 종료', variant: 'info' };
+    if (order.closeReason === 'manual_on_exchange')
+      return { label: '거래소 종료', variant: 'muted' };
     const pnl = Number(order.realizedPnl ?? 0);
-    if (pnl > 0) return { label: 'TP / 익절', variant: 'success' };
-    if (pnl < 0) return { label: 'SL / 손절', variant: 'error' };
+    if (pnl > 0) return { label: '익절', variant: 'success' };
+    if (pnl < 0) return { label: '손절', variant: 'error' };
     return { label: '종료', variant: 'muted' };
   }
   return { label: '활성', variant: 'info' };

--- a/apps/web/src/app/orders/[id]/page.tsx
+++ b/apps/web/src/app/orders/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { OrderChart } from '@/components/order-chart';
+import { CloseReasonBadge } from '@/components/close-reason-badge';
 import { PnlValue } from '@/components/shared/pnl-value';
 import { useBaseCurrency } from '@/hooks/use-base-currency';
 import { useExchangeRate } from '@/hooks/use-exchange-rate';
@@ -96,11 +97,12 @@ export default function OrderDetailPage({ params }: { params: Promise<{ id: stri
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="text-2xl font-bold">{order.symbol}</h1>
             <span className={`text-lg font-semibold uppercase ${sideColor}`}>{order.side}</span>
-            <Badge variant="info">{order.status}</Badge>
+            <Badge variant="info">{order.closedAt ? 'closed' : order.status}</Badge>
             <Badge variant={network === 'mainnet' ? 'orange' : 'purple'}>
               {network === 'mainnet' ? '실거래' : '모의'}
             </Badge>
             {order.leverage ? <Badge variant="muted">{order.leverage}x</Badge> : null}
+            <CloseReasonBadge reason={order.closeReason} />
           </div>
         </div>
         {canClose && (

--- a/apps/web/src/components/close-reason-badge.tsx
+++ b/apps/web/src/components/close-reason-badge.tsx
@@ -1,0 +1,20 @@
+import { Badge } from '@/components/ui/badge';
+import type { CloseReason } from '@/lib/api-client';
+
+const LABEL: Record<
+  CloseReason,
+  { text: string; variant: 'success' | 'error' | 'info' | 'muted' | 'warning' }
+> = {
+  take_profit: { text: 'TP 익절', variant: 'success' },
+  stop_loss: { text: 'SL 손절', variant: 'error' },
+  liquidation: { text: '청산', variant: 'error' },
+  manual: { text: '수동 종료', variant: 'info' },
+  manual_on_exchange: { text: '거래소에서 종료', variant: 'warning' },
+  reconciled_unknown: { text: '동기화', variant: 'muted' },
+};
+
+export function CloseReasonBadge({ reason }: { reason: CloseReason | null | undefined }) {
+  if (!reason) return null;
+  const meta = LABEL[reason] ?? { text: reason, variant: 'muted' as const };
+  return <Badge variant={meta.variant}>{meta.text}</Badge>;
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -246,6 +246,14 @@ export async function cancelOrder(id: string): Promise<{ id: string; status: str
   return res.json();
 }
 
+export type CloseReason =
+  | 'take_profit'
+  | 'stop_loss'
+  | 'liquidation'
+  | 'manual'
+  | 'manual_on_exchange'
+  | 'reconciled_unknown';
+
 export interface OrderDetail {
   order: OrderItem & {
     entryPrice: string | null;
@@ -253,6 +261,7 @@ export interface OrderDetail {
     stopLossPrice: string | null;
     realizedPnl: string | null;
     closedAt: string | null;
+    closeReason: CloseReason | null;
     leverage: number | null;
     positionSide: string | null;
   };
@@ -501,6 +510,7 @@ export interface LlmDecisionItem {
     stopLossPrice: string | null;
     realizedPnl: string | null;
     closedAt: string | null;
+    closeReason: CloseReason | null;
     createdAt: string;
   } | null;
 }

--- a/apps/worker-service/src/orders/orders.module.ts
+++ b/apps/worker-service/src/orders/orders.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { OrdersService } from './orders.service';
+import { PositionReconcilerService } from './reconciler/position-reconciler.service';
 import { RiskModule } from '../risk/risk.module';
 
 @Module({
   imports: [RiskModule],
-  providers: [OrdersService],
+  providers: [OrdersService, PositionReconcilerService],
   exports: [OrdersService],
 })
 export class OrdersModule {}

--- a/apps/worker-service/src/orders/reconciler/position-reconciler.service.ts
+++ b/apps/worker-service/src/orders/reconciler/position-reconciler.service.ts
@@ -1,0 +1,160 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import Redis from 'ioredis';
+import { Kafka, Producer } from 'kafkajs';
+import { KAFKA_TOPICS } from '@coin/kafka-contracts';
+import type { OrderResultEvent, NotificationEvent } from '@coin/kafka-contracts';
+import { BinanceRest, IExchangeRest } from '@coin/exchange-adapters';
+import { decrypt } from '@coin/utils';
+import type { ExchangeId, ExchangeCredentials, IncomeRecord, PositionSide } from '@coin/types';
+import { PrismaService } from '../../prisma/prisma.service';
+import { reconcileOrder, type ReconcileDeps, type ReconcileOutcome } from './reconcile-order';
+
+const REST_ADAPTERS: Record<ExchangeId, () => IExchangeRest> = {
+  binance: () => new BinanceRest(),
+};
+
+const DEFAULT_INTERVAL_MS = 30_000;
+const AUTH_FAIL_THRESHOLD = 3;
+const AUTH_COOLDOWN_SEC = 3600;
+
+@Injectable()
+export class PositionReconcilerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(PositionReconcilerService.name);
+  private readonly redis: Redis;
+  private readonly kafka: Kafka;
+  private readonly producer: Producer;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(private readonly prisma: PrismaService) {
+    this.redis = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT || 6379),
+    });
+    this.kafka = new Kafka({
+      clientId: 'worker-position-reconciler',
+      brokers: (process.env.KAFKA_BROKERS || 'localhost:9092').split(','),
+    });
+    this.producer = this.kafka.producer();
+  }
+
+  async onModuleInit() {
+    await this.producer.connect();
+    const intervalMs = Number(process.env.RECONCILE_INTERVAL_MS) || DEFAULT_INTERVAL_MS;
+    this.timer = setInterval(() => {
+      void this.runOnce().catch((err) => this.logger.error(`Reconcile tick failed: ${err}`));
+    }, intervalMs);
+    this.logger.log(`PositionReconciler started (interval=${intervalMs}ms)`);
+  }
+
+  async onModuleDestroy() {
+    if (this.timer) clearInterval(this.timer);
+    await this.producer.disconnect();
+    this.redis.disconnect();
+  }
+
+  /**
+   * One reconcile pass over all open real-mode orders. Public so it can be
+   * driven from tests with deterministic timing.
+   */
+  async runOnce(): Promise<ReconcileOutcome[]> {
+    if (this.running) {
+      this.logger.debug('Skip overlapping reconcile tick');
+      return [];
+    }
+    this.running = true;
+    try {
+      const orders = await this.prisma.order.findMany({
+        where: { mode: 'real', status: 'filled', closedAt: null },
+        include: { exchangeKey: true },
+        orderBy: { createdAt: 'asc' },
+      });
+      if (orders.length === 0) return [];
+
+      const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+      if (!masterKey) throw new Error('ENCRYPTION_MASTER_KEY not configured');
+
+      const outcomes: ReconcileOutcome[] = [];
+      for (const order of orders) {
+        if (!order.exchangeKeyId || !order.exchangeKey) continue;
+
+        const cooldownKey = `reconcile:auth-cooldown:${order.exchangeKeyId}`;
+        if (await this.redis.get(cooldownKey)) continue;
+
+        const credentials: ExchangeCredentials = {
+          apiKey: decrypt(order.exchangeKey.apiKey, masterKey),
+          secretKey: decrypt(order.exchangeKey.secretKey, masterKey),
+          network: (order.exchangeKey.network as 'mainnet' | 'testnet') ?? 'mainnet',
+        };
+
+        const adapter = REST_ADAPTERS[order.exchange as ExchangeId]();
+        const deps: ReconcileDeps = {
+          prisma: this.prisma,
+          redis: this.redis,
+          getPosition: (s) => adapter.getPosition(credentials, s),
+          getIncome: (opts) => adapter.getIncome(credentials, opts),
+          emit: (events) => this.emit(events, order.userId),
+        };
+
+        try {
+          const outcome = await reconcileOrder(order, deps);
+          outcomes.push(outcome);
+          if (outcome.action === 'closed') {
+            this.logger.log(
+              `Reconciled ${order.id}: ${outcome.reason} realizedPnl=${outcome.realizedPnl ?? 'null'}`,
+            );
+          }
+        } catch (err) {
+          if (this.isAuthError(err)) {
+            await this.bumpAuthFailure(order.exchangeKeyId);
+          }
+          this.logger.warn(`Reconcile failed for ${order.id}: ${err}`);
+        }
+      }
+      return outcomes;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async emit(
+    events: { result?: OrderResultEvent; notification?: NotificationEvent }[],
+    _userId: string,
+  ) {
+    for (const e of events) {
+      if (e.result) {
+        await this.producer.send({
+          topic: KAFKA_TOPICS.TRADING_ORDER_RESULT,
+          messages: [{ key: e.result.userId, value: JSON.stringify(e.result) }],
+        });
+      }
+      if (e.notification) {
+        await this.producer.send({
+          topic: KAFKA_TOPICS.NOTIFICATION_SEND,
+          messages: [{ key: e.notification.userId, value: JSON.stringify(e.notification) }],
+        });
+      }
+    }
+  }
+
+  private isAuthError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    return /-2014|-2015|-1022|API-key|Invalid signature/i.test(err.message);
+  }
+
+  private async bumpAuthFailure(exchangeKeyId: string) {
+    const counterKey = `reconcile:auth-fail:${exchangeKeyId}`;
+    const count = await this.redis.incr(counterKey);
+    await this.redis.expire(counterKey, AUTH_COOLDOWN_SEC);
+    if (count >= AUTH_FAIL_THRESHOLD) {
+      const cooldownKey = `reconcile:auth-cooldown:${exchangeKeyId}`;
+      await this.redis.set(cooldownKey, '1', 'EX', AUTH_COOLDOWN_SEC);
+      this.logger.warn(
+        `Exchange key ${exchangeKeyId} put in 1h auth cooldown after ${count} failures`,
+      );
+    }
+  }
+}
+
+// Export type aliases for tests
+export type { IncomeRecord, PositionSide };

--- a/apps/worker-service/src/orders/reconciler/reconcile-order.test.ts
+++ b/apps/worker-service/src/orders/reconciler/reconcile-order.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { reconcileOrder, type ReconcileDeps } from './reconcile-order';
+
+function makeOrder(overrides: Partial<Parameters<typeof reconcileOrder>[0]> = {}) {
+  return {
+    id: 'o-1',
+    userId: 'u',
+    exchange: 'binance',
+    symbol: 'BTCUSDT',
+    side: 'long',
+    quantity: '0.01',
+    filledQuantity: '0.01',
+    entryPrice: '60000',
+    tpOrderId: 'tp-1',
+    slOrderId: 'sl-1',
+    exchangeKeyId: 'k',
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeDeps(): {
+  deps: ReconcileDeps;
+  redis: { set: ReturnType<typeof vi.fn>; del: ReturnType<typeof vi.fn> };
+  prismaUpdate: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
+  getPosition: ReturnType<typeof vi.fn>;
+  getIncome: ReturnType<typeof vi.fn>;
+} {
+  const redis = {
+    set: vi.fn().mockResolvedValue('OK'),
+    del: vi.fn().mockResolvedValue(1),
+  };
+  const prismaUpdate = vi.fn().mockResolvedValue({ count: 1 });
+  const emit = vi.fn().mockResolvedValue(undefined);
+  const getPosition = vi.fn();
+  const getIncome = vi.fn();
+  const deps: ReconcileDeps = {
+    redis,
+    prisma: { order: { updateMany: prismaUpdate } },
+    getPosition,
+    getIncome,
+    emit,
+  };
+  return { deps, redis, prismaUpdate, emit, getPosition, getIncome };
+}
+
+describe('reconcileOrder', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('포지션이 살아있으면 skip', async () => {
+    const { deps, getPosition, prismaUpdate } = makeDeps();
+    getPosition.mockResolvedValue({
+      symbol: 'BTCUSDT',
+      side: 'long',
+      quantity: '0.01',
+    });
+
+    const result = await reconcileOrder(makeOrder(), deps);
+
+    expect(result).toEqual({ action: 'skip', reason: 'live_position' });
+    expect(prismaUpdate).not.toHaveBeenCalled();
+  });
+
+  it('TP 발동 (양수 PnL + tp/sl 등록됨) → take_profit', async () => {
+    const { deps, getPosition, getIncome, prismaUpdate } = makeDeps();
+    getPosition.mockResolvedValue(null);
+    getIncome.mockResolvedValue([
+      { symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL', income: '5.5', asset: 'USDT', time: 1 },
+      { symbol: 'BTCUSDT', incomeType: 'COMMISSION', income: '-0.05', asset: 'USDT', time: 1 },
+    ]);
+
+    const result = await reconcileOrder(makeOrder(), deps);
+
+    expect(result).toMatchObject({ action: 'closed', reason: 'take_profit' });
+    expect(prismaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'o-1', closedAt: null },
+        data: expect.objectContaining({ status: 'closed', closeReason: 'take_profit' }),
+      }),
+    );
+  });
+
+  it('SL 발동 (음수 PnL + tp/sl 등록됨) → stop_loss', async () => {
+    const { deps, getPosition, getIncome } = makeDeps();
+    getPosition.mockResolvedValue(null);
+    getIncome.mockResolvedValue([
+      { symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL', income: '-3.0', asset: 'USDT', time: 1 },
+    ]);
+
+    const result = await reconcileOrder(makeOrder(), deps);
+    expect(result).toMatchObject({ action: 'closed', reason: 'stop_loss' });
+  });
+
+  it('INSURANCE_CLEAR row 존재 → liquidation', async () => {
+    const { deps, getPosition, getIncome } = makeDeps();
+    getPosition.mockResolvedValue(null);
+    getIncome.mockResolvedValue([
+      { symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL', income: '-10', asset: 'USDT', time: 1 },
+      { symbol: 'BTCUSDT', incomeType: 'INSURANCE_CLEAR', income: '-2', asset: 'USDT', time: 1 },
+    ]);
+
+    const result = await reconcileOrder(makeOrder(), deps);
+    expect(result).toMatchObject({ action: 'closed', reason: 'liquidation' });
+  });
+
+  it('income endpoint이 빈 배열 → reconciled_unknown (다음 tick에 정정)', async () => {
+    const { deps, getPosition, getIncome } = makeDeps();
+    getPosition.mockResolvedValue(null);
+    getIncome.mockResolvedValue([]);
+
+    const result = await reconcileOrder(makeOrder(), deps);
+    expect(result).toEqual({ action: 'closed', reason: 'reconciled_unknown', realizedPnl: null });
+  });
+
+  it('Redis 잠금이 잡히면 skip (lock_held) — 동시 실행 보호', async () => {
+    const { deps, redis } = makeDeps();
+    redis.set.mockResolvedValue(null);
+
+    const result = await reconcileOrder(makeOrder(), deps);
+    expect(result).toEqual({ action: 'skip', reason: 'lock_held' });
+  });
+
+  it('수동 close가 먼저 닫아두면 race_lost — 알림 중복 발송하지 않음', async () => {
+    const { deps, getPosition, getIncome, prismaUpdate, emit } = makeDeps();
+    getPosition.mockResolvedValue(null);
+    getIncome.mockResolvedValue([
+      { symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL', income: '5', asset: 'USDT', time: 1 },
+    ]);
+    prismaUpdate.mockResolvedValue({ count: 0 });
+
+    const result = await reconcileOrder(makeOrder(), deps);
+    expect(result).toEqual({ action: 'skip', reason: 'race_lost' });
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('TP/SL 미등록 + 양수 PnL → manual_on_exchange (사용자가 거래소에서 직접 닫음)', async () => {
+    const { deps, getPosition, getIncome } = makeDeps();
+    getPosition.mockResolvedValue(null);
+    getIncome.mockResolvedValue([
+      { symbol: 'BTCUSDT', incomeType: 'REALIZED_PNL', income: '7', asset: 'USDT', time: 1 },
+    ]);
+
+    const result = await reconcileOrder(makeOrder({ tpOrderId: null, slOrderId: null }), deps);
+    expect(result).toMatchObject({ action: 'closed', reason: 'manual_on_exchange' });
+  });
+});

--- a/apps/worker-service/src/orders/reconciler/reconcile-order.ts
+++ b/apps/worker-service/src/orders/reconciler/reconcile-order.ts
@@ -1,0 +1,198 @@
+import type Redis from 'ioredis';
+import type { OrderResultEvent, NotificationEvent } from '@coin/kafka-contracts';
+import type { IncomeRecord, Position, PositionSide } from '@coin/types';
+
+export type CloseReason =
+  | 'take_profit'
+  | 'stop_loss'
+  | 'liquidation'
+  | 'manual'
+  | 'manual_on_exchange'
+  | 'reconciled_unknown';
+
+export interface ReconcileOrderInput {
+  id: string;
+  userId: string;
+  exchange: string;
+  symbol: string;
+  side: string;
+  quantity: string;
+  filledQuantity: string;
+  entryPrice: string | null;
+  tpOrderId: string | null;
+  slOrderId: string | null;
+  exchangeKeyId: string | null;
+  createdAt: Date;
+}
+
+export interface ReconcileOrderDelegate {
+  updateMany(args: {
+    where: { id: string; closedAt: null };
+    data: {
+      status: string;
+      closedAt: Date;
+      realizedPnl: string | null;
+      closeReason: string;
+    };
+  }): Promise<{ count: number }>;
+}
+
+export interface ReconcileDeps {
+  prisma: { order: ReconcileOrderDelegate };
+  redis: Pick<Redis, 'set' | 'del'>;
+  getPosition(symbol: string): Promise<Position | null>;
+  getIncome(opts: {
+    symbol: string;
+    startTime: number;
+    endTime: number;
+    limit?: number;
+  }): Promise<IncomeRecord[]>;
+  emit(events: { result?: OrderResultEvent; notification?: NotificationEvent }[]): Promise<void>;
+}
+
+export type ReconcileOutcome =
+  | { action: 'skip'; reason: 'live_position' | 'lock_held' | 'race_lost' }
+  | {
+      action: 'closed';
+      reason: CloseReason;
+      realizedPnl: string | null;
+    };
+
+const REASON_LABEL: Record<CloseReason, string> = {
+  take_profit: 'TP 익절',
+  stop_loss: 'SL 손절',
+  liquidation: '청산',
+  manual: '수동 종료',
+  manual_on_exchange: '거래소에서 직접 종료',
+  reconciled_unknown: '동기화 (사유 미상)',
+};
+
+/**
+ * Pure (modulo deps) reconcile of a single order. Idempotent via Redis lock.
+ *
+ * Flow:
+ *   1. Acquire lock keyed by order id (NX). If held, skip.
+ *   2. Query live position. If still open with non-zero qty → skip.
+ *   3. Query income window since order createdAt; pick rows whose tradeId
+ *      matches our recorded tpOrderId / slOrderId. Use those to derive
+ *      reason. Otherwise classify by income types present.
+ *   4. Sum REALIZED_PNL + COMMISSION + FUNDING_FEE for the symbol.
+ *   5. Atomically mark order closed (only if not already closed) and emit
+ *      result + notification events.
+ */
+export async function reconcileOrder(
+  order: ReconcileOrderInput,
+  deps: ReconcileDeps,
+): Promise<ReconcileOutcome> {
+  const lockKey = `reconcile:order:${order.id}`;
+  const acquired = await deps.redis.set(lockKey, '1', 'EX', 60, 'NX');
+  if (!acquired) return { action: 'skip', reason: 'lock_held' };
+
+  try {
+    const live = await deps.getPosition(order.symbol);
+    if (live && Number(live.quantity) > 0) {
+      return { action: 'skip', reason: 'live_position' };
+    }
+
+    // Lookback window: the entire life of the trade plus a small slack on
+    // either side so we don't miss a fill that landed micro-seconds before
+    // our createdAt timestamp.
+    const startTime = order.createdAt.getTime() - 5_000;
+    const endTime = Date.now();
+    const incomes = await deps.getIncome({
+      symbol: order.symbol,
+      startTime,
+      endTime,
+      limit: 1000,
+    });
+
+    const { reason, realizedPnl } = classify(order, incomes);
+
+    // Race-safe update — only flip if still open. Returns 0 rows if a
+    // concurrent writer (manual close) already closed it.
+    const updated = await deps.prisma.order.updateMany({
+      where: { id: order.id, closedAt: null },
+      data: {
+        status: 'closed',
+        closedAt: new Date(),
+        realizedPnl,
+        closeReason: reason,
+      },
+    });
+    if (updated.count === 0) {
+      return { action: 'skip', reason: 'race_lost' };
+    }
+
+    await deps.emit([
+      {
+        notification: {
+          userId: order.userId,
+          type: 'order_filled',
+          title: `포지션 종료 | ${order.exchange.toUpperCase()} ${order.symbol}`,
+          message: `${REASON_LABEL[reason]} — ${realizedPnl ? `PnL ${realizedPnl}` : '실현 손익 미정'}`,
+        },
+      },
+    ]);
+
+    return { action: 'closed', reason, realizedPnl };
+  } finally {
+    await deps.redis.del(lockKey).catch(() => undefined);
+  }
+}
+
+interface Classified {
+  reason: CloseReason;
+  realizedPnl: string | null;
+}
+
+function classify(order: ReconcileOrderInput, incomes: IncomeRecord[]): Classified {
+  const symbolIncomes = incomes.filter((i) => !i.symbol || i.symbol === order.symbol);
+
+  const realized = symbolIncomes.filter((i) => i.incomeType === 'REALIZED_PNL');
+  const commissions = symbolIncomes.filter((i) => i.incomeType === 'COMMISSION');
+  const funding = symbolIncomes.filter((i) => i.incomeType === 'FUNDING_FEE');
+  const insurance = symbolIncomes.filter((i) => i.incomeType === 'INSURANCE_CLEAR');
+
+  // Liquidation: Binance writes INSURANCE_CLEAR rows on forced close.
+  if (insurance.length > 0) {
+    return {
+      reason: 'liquidation',
+      realizedPnl: sumPnl([...realized, ...commissions, ...funding, ...insurance]),
+    };
+  }
+
+  // Match TP/SL by tradeId — Binance reports the trade that closed the
+  // position; tradeId on REALIZED_PNL == the algoOrder's tradeId, but in
+  // practice we store tpOrderId/slOrderId as algoIds, and those don't
+  // appear directly. So we use a heuristic: positive PnL → TP, negative → SL,
+  // ONLY when both tpOrderId and slOrderId were registered. Otherwise mark
+  // as manual_on_exchange.
+  if (realized.length > 0) {
+    const total = sumPnl([...realized, ...commissions, ...funding]);
+    const totalNum = Number(total);
+
+    if (order.tpOrderId && order.slOrderId) {
+      const reason: CloseReason = totalNum >= 0 ? 'take_profit' : 'stop_loss';
+      return { reason, realizedPnl: total };
+    }
+    return { reason: 'manual_on_exchange', realizedPnl: total };
+  }
+
+  // Position closed but no income rows yet (Binance can lag a few seconds).
+  // Estimate from entry vs… we don't have a fill price here, so leave null
+  // and let the next tick refine when income lands.
+  if (order.entryPrice) {
+    const direction = (order.side as PositionSide) === 'long' ? 1 : -1;
+    void direction;
+  }
+  return { reason: 'reconciled_unknown', realizedPnl: null };
+}
+
+function sumPnl(records: IncomeRecord[]): string {
+  let total = 0;
+  for (const r of records) {
+    const v = Number(r.income);
+    if (Number.isFinite(v)) total += v;
+  }
+  return total.toFixed(8);
+}

--- a/apps/worker-service/src/orders/sagas/close-position-saga.ts
+++ b/apps/worker-service/src/orders/sagas/close-position-saga.ts
@@ -85,7 +85,7 @@ export async function executeClosePositionSaga(
   });
   if (!livePosBefore) {
     logger.warn(`Position already gone on exchange — reconciling order ${order.id}`);
-    await markOrderClosed(prisma, order.id, null);
+    await markOrderClosed(prisma, order.id, null, 'manual_on_exchange');
     await emitClosedEvents(
       producer,
       event,
@@ -107,7 +107,7 @@ export async function executeClosePositionSaga(
   } catch (err) {
     if (isPositionGoneError(err)) {
       logger.warn(`Close request rejected (position gone): ${err}. Reconciling.`);
-      await markOrderClosed(prisma, order.id, null);
+      await markOrderClosed(prisma, order.id, null, 'manual_on_exchange');
       await emitClosedEvents(
         producer,
         event,
@@ -148,7 +148,7 @@ export async function executeClosePositionSaga(
     realizedPnl = String(((fill - entry) * qty * direction).toFixed(8));
   }
 
-  await markOrderClosed(prisma, order.id, realizedPnl);
+  await markOrderClosed(prisma, order.id, realizedPnl, 'manual');
   await emitClosedEvents(
     producer,
     event,
@@ -160,10 +160,15 @@ export async function executeClosePositionSaga(
   );
 }
 
-async function markOrderClosed(prisma: PrismaService, orderId: string, realizedPnl: string | null) {
+async function markOrderClosed(
+  prisma: PrismaService,
+  orderId: string,
+  realizedPnl: string | null,
+  closeReason: 'manual' | 'manual_on_exchange' = 'manual',
+) {
   await prisma.order.update({
     where: { id: orderId },
-    data: { status: 'closed', closedAt: new Date(), realizedPnl },
+    data: { status: 'closed', closedAt: new Date(), realizedPnl, closeReason },
   });
 }
 

--- a/packages/database/prisma/migrations/20260501230000_add_close_reason/migration.sql
+++ b/packages/database/prisma/migrations/20260501230000_add_close_reason/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN "closeReason" TEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -95,6 +95,7 @@ model Order {
   slOrderId        String?
   realizedPnl      String?
   closedAt         DateTime?
+  closeReason      String?      // 'take_profit' | 'stop_loss' | 'liquidation' | 'manual' | 'manual_on_exchange' | 'reconciled_unknown'
   createdAt        DateTime     @default(now())
   updatedAt        DateTime     @updatedAt
   user             User         @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/packages/exchange-adapters/src/binance/binance.rest.ts
+++ b/packages/exchange-adapters/src/binance/binance.rest.ts
@@ -11,6 +11,7 @@ import {
   PositionSide,
   MarginType,
   SymbolFilter,
+  IncomeRecord,
 } from '@coin/types';
 import { IExchangeRest } from '../interfaces/exchange-rest';
 
@@ -413,6 +414,52 @@ export class BinanceRest implements IExchangeRest {
       feeCurrency: '',
       timestamp: data.updateTime ?? Date.now(),
     };
+  }
+
+  /**
+   * Binance Futures income endpoint. Used by the position reconciler to
+   * discover authoritative realized PnL after a TP/SL/liquidation fires.
+   * Each entry's `tradeId` ties back to the closing trade so callers can
+   * correlate against tpOrderId / slOrderId stored at entry time.
+   */
+  async getIncome(
+    credentials: ExchangeCredentials,
+    opts: {
+      symbol?: string;
+      incomeType?: string;
+      startTime?: number;
+      endTime?: number;
+      limit?: number;
+    },
+  ): Promise<IncomeRecord[]> {
+    const params: Record<string, string> = {};
+    if (opts.symbol) params.symbol = opts.symbol;
+    if (opts.incomeType) params.incomeType = opts.incomeType;
+    if (opts.startTime != null) params.startTime = String(opts.startTime);
+    if (opts.endTime != null) params.endTime = String(opts.endTime);
+    if (opts.limit != null) params.limit = String(opts.limit);
+
+    const res = await this.signedRequest(credentials, 'GET', '/fapi/v1/income', params);
+    const data = (await res.json()) as Array<{
+      symbol?: string;
+      incomeType: string;
+      income: string;
+      asset: string;
+      time: number;
+      tradeId?: string;
+      tranId?: string;
+      info?: string;
+    }>;
+    return data.map((r) => ({
+      symbol: r.symbol,
+      incomeType: r.incomeType,
+      income: r.income,
+      asset: r.asset,
+      time: r.time,
+      tradeId: r.tradeId,
+      tranId: r.tranId,
+      info: r.info,
+    }));
   }
 
   async getSymbolFilter(symbol: string): Promise<SymbolFilter> {

--- a/packages/exchange-adapters/src/interfaces/exchange-rest.ts
+++ b/packages/exchange-adapters/src/interfaces/exchange-rest.ts
@@ -10,6 +10,7 @@ import {
   PositionSide,
   MarginType,
   SymbolFilter,
+  IncomeRecord,
 } from '@coin/types';
 
 export interface IExchangeRest {
@@ -66,4 +67,14 @@ export interface IExchangeRest {
     quantity: string,
   ): Promise<OrderResult>;
   getSymbolFilter(symbol: string): Promise<SymbolFilter>;
+  getIncome(
+    credentials: ExchangeCredentials,
+    opts: {
+      symbol?: string;
+      incomeType?: string;
+      startTime?: number;
+      endTime?: number;
+      limit?: number;
+    },
+  ): Promise<IncomeRecord[]>;
 }

--- a/packages/types/src/exchange.ts
+++ b/packages/types/src/exchange.ts
@@ -127,3 +127,35 @@ export interface SymbolFilter {
   minNotional: string;
   tickSize: string;
 }
+
+export type IncomeType =
+  | 'REALIZED_PNL'
+  | 'COMMISSION'
+  | 'FUNDING_FEE'
+  | 'INSURANCE_CLEAR'
+  | 'TRANSFER'
+  | 'WELCOME_BONUS'
+  | 'REFERRAL_KICKBACK'
+  | 'COMMISSION_REBATE'
+  | 'API_REBATE'
+  | 'CONTEST_REWARD'
+  | 'CROSS_COLLATERAL_TRANSFER'
+  | 'OPTIONS_PREMIUM_FEE'
+  | 'OPTIONS_SETTLE_PROFIT'
+  | 'INTERNAL_TRANSFER'
+  | 'AUTO_EXCHANGE'
+  | 'DELIVERED_SETTELMENT'
+  | 'COIN_SWAP_DEPOSIT'
+  | 'COIN_SWAP_WITHDRAW'
+  | 'POSITION_LIMIT_INCREASE_FEE';
+
+export interface IncomeRecord {
+  symbol?: string;
+  incomeType: IncomeType | string;
+  income: string;
+  asset: string;
+  time: number;
+  tradeId?: string;
+  tranId?: string;
+  info?: string;
+}


### PR DESCRIPTION
Closes #98.

PR3 + #97에서 TP/SL을 algoOrder로 부착하지만 Binance가 fill을 푸시하지 않아 (User Data Stream 미사용) DB에 ghost open position이 남는 문제. 수동 종료(#97)는 사후 임시방편이었음.

## Worker
- 새 `PositionReconcilerService` — 30초 주기 `setInterval` (`RECONCILE_INTERVAL_MS` 오버라이드)
- 깊은 모듈 `reconcileOrder()` — deps 주입, isolated 테스트 가능
- 알고리즘:
  1. `getPosition` 으로 포지션 사라짐 감지
  2. 사라졌으면 `getIncome` 으로 `REALIZED_PNL + COMMISSION + FUNDING_FEE` 합산해서 정확한 실현 손익
  3. INSURANCE_CLEAR 행 있으면 liquidation, TP/SL 등록 + 양수 PnL → take_profit 등 분류
- Race-safe: `updateMany WHERE closedAt IS NULL` + Redis 락 (`reconcile:order:<id>`) — 수동 close와 중복 알림 방지
- 인증 실패 쿨다운: 키당 3회 실패 → Redis 1h skip
- close-position-saga도 closeReason 세팅 (`manual` / `manual_on_exchange`)

## Adapter / types
- `BinanceRest.getIncome()` 신규 (`/fapi/v1/income`)
- `IncomeRecord`, `IncomeType` 타입 `@coin/types` 에 노출

## Schema
- `Order.closeReason String?` 컬럼 추가 + 마이그레이션
- 값: `take_profit | stop_loss | liquidation | manual | manual_on_exchange | reconciled_unknown`

## API / Frontend
- `OrderResponse` DTO에 closeReason 추가
- `ActivityService` description에 한국어 사유 라벨 + 종료 상태 표기
- `<CloseReasonBadge>` 컴포넌트
- 주문 상세 헤더 + 대시보드 outcome 매핑 closeReason 우선 사용

## Tests
- `reconcileOrder` 8 시나리오 (live/TP/SL/liquidation/empty income/lock/race/no-tpsl)
- close-position-saga 5 시나리오 그대로 그린
- api 57 + worker 13 + web 41 모두 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a background position reconciliation worker that closes ghost futures positions by querying Binance income data and recording structured close reasons, and surface those reasons across API and web UI.

New Features:
- Introduce a PositionReconciler worker service that periodically inspects open real-mode orders, reconciles them against live positions and income records, and auto-closes orders when positions are gone.
- Expose Binance futures income data via a new getIncome REST adapter method and shared IncomeRecord/IncomeType types.
- Add structured order close reasons to the Order model and API response so TP/SL, liquidation, manual, and reconciled closures can be distinguished in clients.
- Display close reasons and derived outcomes in the dashboard, order detail header, and activity feed using dedicated labels and badges.

Bug Fixes:
- Ensure orders closed directly on the exchange or via TP/SL/liquidation are correctly reflected as closed in the database instead of remaining as ghost open positions.

Enhancements:
- Make manual close-position saga set explicit close reasons for locally initiated closes.
- Improve activity and dashboard status labels to reflect closed orders and their exit reasons more clearly.

Tests:
- Add unit tests covering multiple position reconciliation scenarios including TP/SL, liquidation, empty income responses, locking behavior, and race conditions.